### PR TITLE
Add Copilot Code Review as a review provider option

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,14 +41,14 @@ Assuming you have staged changes, the agent will start a review using LGTM and t
 - **Model Selection**: Choose other language model available to VS Code via the **LGTM: Select Chat Model** command available in the Command Palette (press `Cmd+Shift+P` or `Ctrl+Shift+P`).
 - **Pull Request Integration**: Review pull requests from the GitHub Pull Request or Bitbucket extensions.
 - **Agent Support**: Adds tools to enable automatic reviews in agent mode:
-    - `#review`: Reviews changes between two git references (branches, tags, or commits)
-    - `#reviewStaged`: Reviews only staged changes in your working directory
-    - `#reviewUnstaged`: Reviews only unstaged changes in your working directory
-    - Example usage: `After your changes, run all tests and run #reviewUnstaged to check your work.`
+  - `#review`: Reviews changes between two git references (branches, tags, or commits)
+  - `#reviewStaged`: Reviews only staged changes in your working directory
+  - `#reviewUnstaged`: Reviews only unstaged changes in your working directory
+  - Example usage: `After your changes, run all tests and run #reviewUnstaged to check your work.`
 - **Chat Integration**: Review content remains in chat history for follow-up questions by omitting `@lgtm`.
 - **Automatic Fixes**: Use the `Fix` action on a review comment to fix it automatically. This will use the language model configured for inline chat.
-- **Project-Specific Context Files**: By default,`AGENTS.md` is added to the review prompt. Can be configured using the `Lgtm: Context Files` setting.
-- **Custom Instructions**: Add global custom instructions via the `Lgtm: Custom Prompt` setting (e.g., change the language of review comments by adding `- In the final JSON output, use Spanish for the `comment` field.`).
+- **Project-Specific Context Files**: By default, `AGENTS.md` is added to the review prompt. Can be configured using the `Lgtm: Context Files` setting.
+- **Custom Instructions**: Add global custom instructions via the `Lgtm: Custom Prompt` setting (e.g., change the language of review comments by adding `- In the final JSON output, use Spanish for the 'comment' field.`).
 
 ## Limitations
 

--- a/package.json
+++ b/package.json
@@ -229,6 +229,19 @@
                     "default": "copilot:gpt-4.1",
                     "markdownDescription": "Default review provider to use for generating review comments. Use the 'LGTM: Select Chat Model' command to choose from available chat models or the special `copilot-code-review` provider. Note that non-default chat models may not be available, may require changes to the [Copilot settings](https://github.com/settings/copilot), or have stricter rate limits."
                 },
+                "lgtm.preferredModels": {
+                    "type": "array",
+                    "default": [
+                        "copilot:claude-sonnet-4.5",
+                        "copilot:claude-sonnet-4.6",
+                        "claude-model-provider:claude-sonnet-4-5",
+                        "claude-model-provider:claude-sonnet-4-6"
+                    ],
+                    "items": {
+                        "type": "string"
+                    },
+                    "markdownDescription": "Review providers to prioritize in the picker. The current `lgtm.chatModel` is always added to the Preferred Models section automatically. Entries that are unavailable or unsupported are ignored, and preferred providers are omitted from the other sections."
+                },
                 "lgtm.selectChatModelForReview": {
                     "type": "string",
                     "enum": [

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
                 "commands": [
                     {
                         "name": "review",
-                        "description": "Review changes. Specify branches, commits, or tags, e.g. `/review develop main`. Use `model:id` to select models inline. Use `context:path` to override attached context files or `context:none` to disable them for one review. Leave empty for interactive."
+                        "description": "Review changes. Specify branches, commits, or tags, e.g. `/review develop main`. Use `model:id` to select review providers inline, including `model:copilot-code-review`. Use `context:path` to override attached context files or `context:none` to disable them for one review. Leave empty for interactive."
                     }
                 ]
             }
@@ -227,7 +227,7 @@
                 "lgtm.chatModel": {
                     "type": "string",
                     "default": "copilot:gpt-4.1",
-                    "markdownDescription": "Default chat model to use for generating review comments. Use the 'LGTM: Select Chat Model' command to choose from available models. Note that non-default models may not be available, may require changes to the [Copilot settings](https://github.com/settings/copilot), or have stricter rate limits."
+                    "markdownDescription": "Default review provider to use for generating review comments. Use the 'LGTM: Select Chat Model' command to choose from available chat models or the special `copilot-code-review` provider. Note that non-default chat models may not be available, may require changes to the [Copilot settings](https://github.com/settings/copilot), or have stricter rate limits."
                 },
                 "lgtm.selectChatModelForReview": {
                     "type": "string",
@@ -237,10 +237,10 @@
                     ],
                     "default": "Use default",
                     "enumDescriptions": [
-                        "Use the model defined in 'Chat Model'",
-                        "Always ask which model to use when starting a new prompt (supports multi-selection)"
+                        "Use the provider defined in 'Chat Model'",
+                        "Always ask which review provider to use when starting a new prompt (supports multi-selection)"
                     ],
-                    "markdownDescription": "Controls which chat model to use when starting a new review prompt. When set to 'Always ask', you can select multiple models to compare their results."
+                    "markdownDescription": "Controls which review provider to use when starting a new review prompt. When set to 'Always ask', you can select multiple chat models and/or Copilot Code Review to compare their results."
                 },
                 "lgtm.outputModeWithMultipleModels": {
                     "type": "string",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -112,7 +112,6 @@ async function handleSelectChatModel() {
     const models = await vscode.lm.selectChatModels();
     const config = await getConfig();
     const currentModelId = config.getOptions().chatModel;
-    const DONT_FORGET_TO_REMOVE_ME = 'Im debug only.';
     const quickPickItems = getModelQuickPickItems(models ?? []).map((item) => {
         if (item.kind === vscode.QuickPickItemKind.Separator) return item;
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -110,17 +110,14 @@ async function startReviewChat(target: string = '', base: string = '') {
 
 async function handleSelectChatModel() {
     const models = await vscode.lm.selectChatModels();
-    if (!models || models.length === 0) {
-        vscode.window.showWarningMessage('No chat models available.');
-        return;
-    }
-
     const config = await getConfig();
     const currentModelId = config.getOptions().chatModel;
-    const quickPickItems = getModelQuickPickItems(models).map((item) => {
+    const DONT_FORGET_TO_REMOVE_ME = 'Im debug only.';
+    const quickPickItems = getModelQuickPickItems(models ?? []).map((item) => {
         if (item.kind === vscode.QuickPickItemKind.Separator) return item;
 
         const isCurrentModel =
+            item.providerId === currentModelId ||
             item.modelIdWithVendor === currentModelId ||
             item.id === currentModelId;
         const prefix = isCurrentModel ? '$(check)' : '\u2003 ';
@@ -131,15 +128,12 @@ async function handleSelectChatModel() {
     });
     const selectedQuickPickItem = await vscode.window.showQuickPick(
         quickPickItems,
-        { placeHolder: 'Select a chat model for LGTM reviews' }
+        { placeHolder: 'Select a review provider for LGTM reviews' }
     );
-    if (selectedQuickPickItem?.modelIdWithVendor) {
-        await config.setOption(
-            'chatModel',
-            selectedQuickPickItem.modelIdWithVendor
-        );
+    if (selectedQuickPickItem?.providerId) {
+        await config.setOption('chatModel', selectedQuickPickItem.providerId);
         vscode.window.showInformationMessage(
-            `LGTM chat model set to: ${selectedQuickPickItem.name}`
+            `LGTM review provider set to: ${selectedQuickPickItem.name}`
         );
     }
 }

--- a/src/review/copilotCodeReview.ts
+++ b/src/review/copilotCodeReview.ts
@@ -1,6 +1,6 @@
 import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { dirname, join } from 'node:path';
+import { dirname, join, relative, resolve, sep } from 'node:path';
 import * as vscode from 'vscode';
 
 import { sortFileCommentsBySeverity } from '@/review/comment';
@@ -79,6 +79,13 @@ type FileSnapshotPair =
           readonly useWorkspaceFileForCurrent: false;
       };
 
+/**
+ * Run GitHub Copilot Chat's code review command for the prepared diff files.
+ *
+ * API-level failures and cancellations are returned in `ReviewResult.errors`
+ * so callers can keep a normal review result shape. Command execution failures
+ * are treated as infrastructure errors and still reject the call.
+ */
 export async function reviewDiffWithCopilotCodeReview(
     config: Config,
     request: ReviewRequest,
@@ -102,6 +109,8 @@ export async function reviewDiffWithCopilotCodeReview(
 
         tempDir = await mkdtemp(join(tmpdir(), 'lgtm-copilot-review-'));
         const preparedFiles: PreparedFile[] = [];
+        const gatheringMessage = formatGatheringFilesMessage(files);
+        const gatheringIncrement = files.length > 0 ? 100 / files.length : 0;
 
         for (const file of files) {
             if (cancellationToken?.isCancellationRequested) {
@@ -109,8 +118,8 @@ export async function reviewDiffWithCopilotCodeReview(
             }
 
             progress?.report({
-                message: formatGatheringFilesMessage(files),
-                increment: files.length > 0 ? 100 / files.length : 0,
+                message: gatheringMessage,
+                increment: gatheringIncrement,
             });
 
             preparedFiles.push(
@@ -211,6 +220,13 @@ export async function reviewDiffWithCopilotCodeReview(
     };
 }
 
+/**
+ * Build the file pair that Copilot Chat expects for review.
+ *
+ * Workspace files are used directly when the current side exists on disk.
+ * Otherwise we materialize temporary snapshots for staged, committed, deleted,
+ * or renamed content so both sides can be reviewed through stable URIs.
+ */
 async function prepareFileForReview(
     config: Config,
     scope: ReviewScope,
@@ -313,7 +329,20 @@ async function writeSnapshotFile(
     filePath: string,
     content: string
 ): Promise<vscode.Uri> {
-    const fullPath = join(tempDir, directory, filePath);
+    const snapshotRoot = resolve(tempDir, directory);
+    const fullPath = resolve(snapshotRoot, filePath);
+    const relativePath = relative(snapshotRoot, fullPath);
+
+    if (
+        !relativePath ||
+        relativePath === '..' ||
+        relativePath.startsWith(`..${sep}`)
+    ) {
+        throw new Error(
+            `Refusing to write Copilot review snapshot outside the temporary directory: ${filePath}`
+        );
+    }
+
     await mkdir(dirname(fullPath), { recursive: true });
     await writeFile(fullPath, content, 'utf8');
     return vscode.Uri.file(fullPath);
@@ -335,6 +364,9 @@ function getCommentLine(comment: CopilotCodeReviewComment): number {
     return typeof line === 'number' && line >= 0 ? line + 1 : 0;
 }
 
+/**
+ * Normalize Copilot severities to LGTM's 1..5 severity scale where 5 is high.
+ */
 function normalizeSeverity(severity: unknown): number {
     if (typeof severity === 'number' && severity >= 1 && severity <= 5) {
         return severity;
@@ -375,6 +407,8 @@ async function runCopilotCodeReview(
         };
     }
 
+    // This setting belongs to the Copilot Chat extension. Defaulting to true
+    // preserves existing behavior if the setting is absent or renamed.
     const reviewEnabled = vscode.workspace
         .getConfiguration('github.copilot.chat')
         .get<boolean>('reviewAgent.enabled', true);
@@ -418,6 +452,10 @@ async function runCopilotCodeReview(
     return result.result;
 }
 
+/**
+ * Race the review command against cancellation and dispose the listener once
+ * either side wins.
+ */
 async function raceCommandWithCancellation(
     command: PromiseLike<CopilotCodeReviewResult | undefined>,
     cancellationToken?: vscode.CancellationToken

--- a/src/review/copilotCodeReview.ts
+++ b/src/review/copilotCodeReview.ts
@@ -82,9 +82,9 @@ type FileSnapshotPair =
 /**
  * Run GitHub Copilot Chat's code review command for the prepared diff files.
  *
- * API-level failures and cancellations are returned in `ReviewResult.errors`
- * so callers can keep a normal review result shape. Command execution failures
- * are treated as infrastructure errors and still reject the call.
+ * Failures and cancellations are returned in `ReviewResult.errors` so callers
+ * can keep a normal review result shape and surface problems without aborting
+ * the overall review flow.
  */
 export async function reviewDiffWithCopilotCodeReview(
     config: Config,
@@ -439,7 +439,10 @@ async function runCopilotCodeReview(
     }
 
     if (result.type === 'error') {
-        throw result.error;
+        return {
+            type: 'error',
+            reason: formatCommandError(result.error),
+        };
     }
 
     if (!result.result) {
@@ -450,6 +453,11 @@ async function runCopilotCodeReview(
     }
 
     return result.result;
+}
+
+function formatCommandError(error: unknown): string {
+    const message = error instanceof Error ? error.message : String(error);
+    return `GitHub Copilot Chat code review failed: ${message}`;
 }
 
 /**

--- a/src/review/copilotCodeReview.ts
+++ b/src/review/copilotCodeReview.ts
@@ -37,6 +37,19 @@ type CopilotCodeReviewCancelled = {
     readonly type: 'cancelled';
 };
 
+type CommandExecutionResult =
+    | {
+          readonly type: 'command';
+          readonly result: CopilotCodeReviewResult | undefined;
+      }
+    | {
+          readonly type: 'error';
+          readonly error: unknown;
+      }
+    | {
+          readonly type: 'cancelled';
+      };
+
 type CopilotCodeReviewResult =
     | CopilotCodeReviewSuccess
     | CopilotCodeReviewError
@@ -117,10 +130,11 @@ export async function reviewDiffWithCopilotCodeReview(
             };
         }
 
-        progress?.report({ message: 'Reviewing...', increment: -100 });
+        progress?.report({ message: 'Reviewing...' });
 
         const result = await runCopilotCodeReview(
-            preparedFiles.map((preparedFile) => preparedFile.input)
+            preparedFiles.map((preparedFile) => preparedFile.input),
+            cancellationToken
         );
 
         if (result.type === 'error') {
@@ -175,7 +189,17 @@ export async function reviewDiffWithCopilotCodeReview(
         }
     } finally {
         if (tempDir) {
-            await rm(tempDir, { recursive: true, force: true });
+            await rm(tempDir, { recursive: true, force: true }).catch(
+                (error: unknown) => {
+                    const message =
+                        error instanceof Error ? error.message : String(error);
+                    errors.push(
+                        new Error(
+                            `Failed to remove temporary Copilot review files: ${message}`
+                        )
+                    );
+                }
+            );
         }
     }
 
@@ -340,7 +364,8 @@ function normalizeSeverity(severity: unknown): number {
 }
 
 async function runCopilotCodeReview(
-    files: readonly CodeReviewFileInput[]
+    files: readonly CodeReviewFileInput[],
+    cancellationToken?: vscode.CancellationToken
 ): Promise<CopilotCodeReviewResult> {
     const extension = vscode.extensions.getExtension('GitHub.copilot-chat');
     if (!extension) {
@@ -362,18 +387,80 @@ async function runCopilotCodeReview(
 
     await extension.activate();
 
-    const result =
-        await vscode.commands.executeCommand<CopilotCodeReviewResult>(
-            'github.copilot.chat.codeReview.run',
-            { files }
-        );
+    if (cancellationToken?.isCancellationRequested) {
+        return { type: 'cancelled' };
+    }
 
-    if (!result) {
+    const command = vscode.commands.executeCommand<CopilotCodeReviewResult>(
+        'github.copilot.chat.codeReview.run',
+        { files }
+    );
+    const result = await raceCommandWithCancellation(
+        command,
+        cancellationToken
+    );
+
+    if (result.type === 'cancelled') {
+        return result;
+    }
+
+    if (result.type === 'error') {
+        throw result.error;
+    }
+
+    if (!result.result) {
         return {
             type: 'error',
             reason: 'No result returned from GitHub Copilot Chat.',
         };
     }
 
-    return result;
+    return result.result;
+}
+
+async function raceCommandWithCancellation(
+    command: PromiseLike<CopilotCodeReviewResult | undefined>,
+    cancellationToken?: vscode.CancellationToken
+): Promise<CommandExecutionResult> {
+    if (!cancellationToken) {
+        try {
+            return {
+                type: 'command',
+                result: await command,
+            };
+        } catch (error) {
+            return {
+                type: 'error',
+                error,
+            };
+        }
+    }
+
+    let disposeCancellation: (() => void) | undefined;
+    const cancellation = new Promise<CommandExecutionResult>((resolve) => {
+        const subscription = cancellationToken.onCancellationRequested(() => {
+            resolve({ type: 'cancelled' });
+        });
+        disposeCancellation = () => subscription.dispose();
+    });
+
+    try {
+        return await Promise.race([
+            command.then(
+                (result) =>
+                    ({
+                        type: 'command',
+                        result,
+                    }) as const,
+                (error) =>
+                    ({
+                        type: 'error',
+                        error,
+                    }) as const
+            ),
+            cancellation,
+        ]);
+    } finally {
+        disposeCancellation?.();
+    }
 }

--- a/src/review/copilotCodeReview.ts
+++ b/src/review/copilotCodeReview.ts
@@ -1,0 +1,379 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import * as vscode from 'vscode';
+
+import { sortFileCommentsBySeverity } from '@/review/comment';
+import { formatGatheringFilesMessage } from '@/review/formatGatheringFilesMessage';
+import type { Config } from '@/types/Config';
+import type { DiffFile } from '@/types/DiffFile';
+import type { FileComments } from '@/types/FileComments';
+import { UncommittedRef } from '@/types/Ref';
+import type { ReviewComment } from '@/types/ReviewComment';
+import type { ReviewRequest, ReviewScope } from '@/types/ReviewRequest';
+import type { ReviewResult } from '@/types/ReviewResult';
+import { GIT_EMPTY_TREE_HASH } from '@/utils/git';
+
+type Progress = {
+    report: (value: { message?: string; increment?: number }) => void;
+};
+
+type CodeReviewFileInput = {
+    readonly currentUri: vscode.Uri;
+    readonly baseUri?: vscode.Uri;
+};
+
+type CopilotCodeReviewSuccess = {
+    readonly type: 'success';
+    readonly comments: readonly CopilotCodeReviewComment[];
+};
+
+type CopilotCodeReviewError = {
+    readonly type: 'error';
+    readonly reason: string;
+};
+
+type CopilotCodeReviewCancelled = {
+    readonly type: 'cancelled';
+};
+
+type CopilotCodeReviewResult =
+    | CopilotCodeReviewSuccess
+    | CopilotCodeReviewError
+    | CopilotCodeReviewCancelled;
+
+type CopilotCodeReviewComment = {
+    readonly uri?: vscode.Uri;
+    readonly range?: vscode.Range | { start?: { line?: number } };
+    readonly body?: string;
+    readonly severity?: unknown;
+};
+
+type PreparedFile = {
+    readonly file: DiffFile;
+    readonly input: CodeReviewFileInput;
+};
+
+type FileSnapshotPair =
+    | {
+          readonly currentContent?: undefined;
+          readonly baseContent?: string;
+          readonly useWorkspaceFileForCurrent: true;
+      }
+    | {
+          readonly currentContent: string;
+          readonly baseContent?: string;
+          readonly useWorkspaceFileForCurrent: false;
+      };
+
+export async function reviewDiffWithCopilotCodeReview(
+    config: Config,
+    request: ReviewRequest,
+    files: DiffFile[],
+    progress?: Progress,
+    cancellationToken?: vscode.CancellationToken
+): Promise<ReviewResult> {
+    const errors: Error[] = [];
+    const fileComments: FileComments[] = [];
+    let tempDir: string | undefined;
+
+    try {
+        if (cancellationToken?.isCancellationRequested) {
+            return {
+                request,
+                files,
+                fileComments,
+                errors,
+            };
+        }
+
+        tempDir = await mkdtemp(join(tmpdir(), 'lgtm-copilot-review-'));
+        const preparedFiles: PreparedFile[] = [];
+
+        for (const file of files) {
+            if (cancellationToken?.isCancellationRequested) {
+                break;
+            }
+
+            progress?.report({
+                message: formatGatheringFilesMessage(files),
+                increment: files.length > 0 ? 100 / files.length : 0,
+            });
+
+            preparedFiles.push(
+                await prepareFileForReview(config, request.scope, file, tempDir)
+            );
+        }
+
+        if (
+            preparedFiles.length === 0 ||
+            cancellationToken?.isCancellationRequested
+        ) {
+            return {
+                request,
+                files,
+                fileComments,
+                errors,
+            };
+        }
+
+        progress?.report({ message: 'Reviewing...', increment: -100 });
+
+        const result = await runCopilotCodeReview(
+            preparedFiles.map((preparedFile) => preparedFile.input)
+        );
+
+        if (result.type === 'error') {
+            errors.push(new Error(result.reason));
+        } else if (result.type === 'cancelled') {
+            errors.push(new Error('Copilot Code Review cancelled.'));
+        } else {
+            const commentsByFile = new Map<string, ReviewComment[]>();
+            const pathByUri = new Map<string, string>();
+
+            for (const preparedFile of preparedFiles) {
+                pathByUri.set(
+                    preparedFile.input.currentUri.toString(),
+                    preparedFile.file.file
+                );
+                if (preparedFile.input.baseUri) {
+                    pathByUri.set(
+                        preparedFile.input.baseUri.toString(),
+                        preparedFile.file.file
+                    );
+                }
+            }
+
+            for (const comment of result.comments) {
+                const filePath = resolveCommentFilePath(comment, pathByUri);
+                if (!filePath) {
+                    continue;
+                }
+
+                const normalized: ReviewComment = {
+                    file: filePath,
+                    comment:
+                        comment.body?.trim() ||
+                        'Copilot Code Review flagged an issue.',
+                    line: getCommentLine(comment),
+                    severity: normalizeSeverity(comment.severity),
+                };
+
+                const existing = commentsByFile.get(filePath) ?? [];
+                existing.push(normalized);
+                commentsByFile.set(filePath, existing);
+            }
+
+            fileComments.push(
+                ...sortFileCommentsBySeverity(
+                    Array.from(commentsByFile, ([target, comments]) => ({
+                        target,
+                        comments,
+                    }))
+                )
+            );
+        }
+    } finally {
+        if (tempDir) {
+            await rm(tempDir, { recursive: true, force: true });
+        }
+    }
+
+    return {
+        request,
+        files,
+        fileComments,
+        errors,
+    };
+}
+
+async function prepareFileForReview(
+    config: Config,
+    scope: ReviewScope,
+    file: DiffFile,
+    tempDir: string
+): Promise<PreparedFile> {
+    const snapshot = await getFileSnapshotPair(config, scope, file);
+
+    const currentUri = snapshot.useWorkspaceFileForCurrent
+        ? getWorkspaceFileUri(config, file.file)
+        : await writeSnapshotFile(
+              tempDir,
+              'current',
+              file.file,
+              snapshot.currentContent
+          );
+
+    const baseUri =
+        snapshot.baseContent === undefined
+            ? undefined
+            : await writeSnapshotFile(
+                  tempDir,
+                  'base',
+                  file.from ?? file.file,
+                  snapshot.baseContent
+              );
+
+    return {
+        file,
+        input: {
+            currentUri,
+            baseUri,
+        },
+    };
+}
+
+async function getFileSnapshotPair(
+    config: Config,
+    scope: ReviewScope,
+    file: DiffFile
+): Promise<FileSnapshotPair> {
+    const previousPath = file.from ?? file.file;
+
+    if (!scope.isCommitted) {
+        if (scope.target === UncommittedRef.Staged) {
+            return {
+                baseContent: await config.git.getFileContentAtRef(
+                    'HEAD',
+                    previousPath
+                ),
+                currentContent:
+                    file.status === 'D'
+                        ? ''
+                        : ((await config.git.getFileContentAtIndex(
+                              file.file
+                          )) ?? ''),
+                useWorkspaceFileForCurrent: false,
+            };
+        }
+
+        if (file.status === 'D') {
+            return {
+                baseContent:
+                    await config.git.getFileContentAtIndex(previousPath),
+                currentContent: '',
+                useWorkspaceFileForCurrent: false,
+            };
+        }
+
+        return {
+            baseContent: await config.git.getFileContentAtIndex(previousPath),
+            useWorkspaceFileForCurrent: true,
+        };
+    }
+
+    const baseRef =
+        scope.base === GIT_EMPTY_TREE_HASH
+            ? undefined
+            : await config.git.getMergeBase(scope.base, scope.target);
+
+    return {
+        baseContent:
+            baseRef === undefined
+                ? undefined
+                : await config.git.getFileContentAtRef(baseRef, previousPath),
+        currentContent:
+            (await config.git.getFileContentAtRef(scope.target, file.file)) ??
+            '',
+        useWorkspaceFileForCurrent: false,
+    };
+}
+
+function getWorkspaceFileUri(config: Config, filePath: string): vscode.Uri {
+    return vscode.Uri.file(join(config.gitRoot, filePath));
+}
+
+async function writeSnapshotFile(
+    tempDir: string,
+    directory: 'base' | 'current',
+    filePath: string,
+    content: string
+): Promise<vscode.Uri> {
+    const fullPath = join(tempDir, directory, filePath);
+    await mkdir(dirname(fullPath), { recursive: true });
+    await writeFile(fullPath, content, 'utf8');
+    return vscode.Uri.file(fullPath);
+}
+
+function resolveCommentFilePath(
+    comment: CopilotCodeReviewComment,
+    pathByUri: Map<string, string>
+): string | undefined {
+    if (!comment.uri) {
+        return;
+    }
+
+    return pathByUri.get(comment.uri.toString());
+}
+
+function getCommentLine(comment: CopilotCodeReviewComment): number {
+    const line = comment.range?.start?.line;
+    return typeof line === 'number' && line >= 0 ? line + 1 : 0;
+}
+
+function normalizeSeverity(severity: unknown): number {
+    if (typeof severity === 'number' && severity >= 1 && severity <= 5) {
+        return severity;
+    }
+
+    if (typeof severity !== 'string') {
+        return 3;
+    }
+
+    switch (severity.toLowerCase()) {
+        case 'critical':
+        case 'error':
+        case 'high':
+            return 5;
+        case 'warning':
+        case 'medium':
+            return 4;
+        case 'info':
+        case 'notice':
+            return 3;
+        case 'low':
+        case 'hint':
+            return 2;
+        default:
+            return 3;
+    }
+}
+
+async function runCopilotCodeReview(
+    files: readonly CodeReviewFileInput[]
+): Promise<CopilotCodeReviewResult> {
+    const extension = vscode.extensions.getExtension('GitHub.copilot-chat');
+    if (!extension) {
+        return {
+            type: 'error',
+            reason: 'GitHub Copilot Chat is not installed.',
+        };
+    }
+
+    const reviewEnabled = vscode.workspace
+        .getConfiguration('github.copilot.chat')
+        .get<boolean>('reviewAgent.enabled', true);
+    if (!reviewEnabled) {
+        return {
+            type: 'error',
+            reason: 'GitHub Copilot Chat code review is disabled in settings.',
+        };
+    }
+
+    await extension.activate();
+
+    const result =
+        await vscode.commands.executeCommand<CopilotCodeReviewResult>(
+            'github.copilot.chat.codeReview.run',
+            { files }
+        );
+
+    if (!result) {
+        return {
+            type: 'error',
+            reason: 'No result returned from GitHub Copilot Chat.',
+        };
+    }
+
+    return result;
+}

--- a/src/review/formatGatheringFilesMessage.ts
+++ b/src/review/formatGatheringFilesMessage.ts
@@ -1,0 +1,18 @@
+import type { DiffFile } from '@/types/DiffFile';
+
+export function formatGatheringFilesMessage(
+    files: DiffFile[],
+    numFileNamesShown = 4
+): string {
+    const fileNames = files
+        .slice(0, numFileNamesShown)
+        .map((f) => f.file.split('/').pop() || f.file)
+        .join(', ');
+    const remainingCount = files.length - numFileNamesShown;
+
+    if (remainingCount <= 0) {
+        return `Gathering changes for ${fileNames}...`;
+    }
+
+    return `Gathering changes for ${fileNames}, and ${remainingCount} other ${remainingCount === 1 ? 'file' : 'files'}...`;
+}

--- a/src/review/review.ts
+++ b/src/review/review.ts
@@ -5,6 +5,7 @@ import type { DiffFile } from '@/types/DiffFile';
 import { ModelError } from '@/types/ModelError';
 import type { PromptType } from '@/types/PromptType';
 import type { ReviewComment } from '@/types/ReviewComment';
+import { isCopilotCodeReviewProviderId } from '@/types/ReviewProvider';
 import type { ReviewRequest } from '@/types/ReviewRequest';
 import type { ReviewResult } from '@/types/ReviewResult';
 import { parallelLimit } from '@/utils/async';
@@ -13,24 +14,51 @@ import { isPathNotExcluded } from '@/utils/glob';
 import { saveToFile } from '@/utils/saveToFile';
 import { parseResponse, sortFileCommentsBySeverity } from './comment';
 import { loadReviewContextFiles } from './contextFiles';
+import { reviewDiffWithCopilotCodeReview } from './copilotCodeReview';
+import { formatGatheringFilesMessage } from './formatGatheringFilesMessage';
 import { ModelRequest } from './ModelRequest';
 import { defaultPromptType, toPromptTypes } from './prompt';
+
+type ReviewDiffOptions = {
+    providerId?: string;
+    progress?: Progress<{ message?: string; increment?: number }>;
+    cancellationToken?: CancellationToken;
+};
 
 export async function reviewDiff(
     config: Config,
     request: ReviewRequest,
-    progress?: Progress<{ message?: string; increment?: number }>,
-    cancellationToken?: CancellationToken
+    options?: ReviewDiffOptions
 ): Promise<ReviewResult> {
+    const providerId = options?.providerId ?? config.getOptions().chatModel;
+    const progress = options?.progress;
+    const cancellationToken = options?.cancellationToken;
     const diffFiles = await config.git.getChangedFiles(request.scope);
-    const options = config.getOptions();
+    const reviewOptions = config.getOptions();
     const files = diffFiles.filter(
         (file) =>
-            isPathNotExcluded(file.file, options.excludeGlobs) &&
-            file.status !== 'D' // ignore deleted files
+            isPathNotExcluded(file.file, reviewOptions.excludeGlobs) &&
+            (isCopilotCodeReviewProviderId(providerId) || file.status !== 'D')
     );
+
+    if (isCopilotCodeReviewProviderId(providerId)) {
+        const result = await reviewDiffWithCopilotCodeReview(
+            config,
+            request,
+            files,
+            progress,
+            cancellationToken
+        );
+
+        if (reviewOptions.saveOutputToFile) {
+            saveToFile(config, result);
+        }
+
+        return result;
+    }
+
     const configuredContextFiles =
-        request.contextFilesOverride ?? options.contextFiles;
+        request.contextFilesOverride ?? reviewOptions.contextFiles;
     const contextFiles = await loadReviewContextFiles(configuredContextFiles);
 
     //TODO reorder to get relevant input files together, e.g.
@@ -68,7 +96,7 @@ export async function reviewDiff(
     };
 
     // Save to file if the setting is enabled
-    if (options.saveOutputToFile) {
+    if (reviewOptions.saveOutputToFile) {
         saveToFile(config, result);
     }
 
@@ -249,21 +277,4 @@ async function processRequest(
         commentsForFile.push(comment);
         commentsPerFile.set(comment.file, commentsForFile);
     }
-}
-
-export function formatGatheringFilesMessage(
-    files: DiffFile[],
-    numFileNamesShown = 4
-): string {
-    const fileNames = files
-        .slice(0, numFileNamesShown)
-        .map((f) => f.file.split('/').pop() || f.file)
-        .join(', ');
-    const remainingCount = files.length - numFileNamesShown;
-
-    if (remainingCount <= 0) {
-        return `Gathering changes for ${fileNames}...`;
-    }
-
-    return `Gathering changes for ${fileNames}, and ${remainingCount} other ${remainingCount === 1 ? 'file' : 'files'}...`;
 }

--- a/src/review/review.ts
+++ b/src/review/review.ts
@@ -38,6 +38,9 @@ export async function reviewDiff(
     const files = diffFiles.filter(
         (file) =>
             isPathNotExcluded(file.file, reviewOptions.excludeGlobs) &&
+            // Copilot Code Review can review deleted files because it builds
+            // temporary before/after snapshots instead of reading only the
+            // current workspace file.
             (isCopilotCodeReviewProviderId(providerId) || file.status !== 'D')
     );
 

--- a/src/test/unit/review/copilotCodeReview.test.ts
+++ b/src/test/unit/review/copilotCodeReview.test.ts
@@ -1,0 +1,698 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { reviewDiffWithCopilotCodeReview } from '@/review/copilotCodeReview';
+import type { Config } from '@/types/Config';
+import { UncommittedRef } from '@/types/Ref';
+import { GIT_EMPTY_TREE_HASH } from '@/utils/git';
+
+type TestGit = {
+    getFileContentAtRef: ReturnType<typeof vi.fn>;
+    getFileContentAtIndex: ReturnType<typeof vi.fn>;
+    getMergeBase: ReturnType<typeof vi.fn>;
+};
+
+type TestConfig = {
+    gitRoot: string;
+    git: TestGit;
+};
+
+const vscodeMocks = vi.hoisted(() => ({
+    getExtension: vi.fn(),
+    executeCommand: vi.fn(),
+    getConfiguration: vi.fn(),
+}));
+
+vi.mock('vscode', () => ({
+    Uri: {
+        file: (fsPath: string) => ({
+            fsPath,
+            toString: () => `file://${fsPath}`,
+        }),
+    },
+    commands: {
+        executeCommand: vscodeMocks.executeCommand,
+    },
+    extensions: {
+        getExtension: vscodeMocks.getExtension,
+    },
+    workspace: {
+        getConfiguration: vscodeMocks.getConfiguration,
+    },
+}));
+
+describe('reviewDiffWithCopilotCodeReview', () => {
+    const tempDirs: string[] = [];
+
+    function createWorkspaceFile(relativePath: string, content: string) {
+        const gitRoot = tempDirs.at(-1);
+        if (!gitRoot) {
+            throw new Error('Expected a temporary git root to exist.');
+        }
+        const fullPath = join(gitRoot, relativePath);
+        writeFileSync(fullPath, content, 'utf8');
+        return fullPath;
+    }
+
+    function createConfig(overrides?: Partial<TestConfig>): TestConfig {
+        const gitRoot = mkdtempSync(join(tmpdir(), 'lgtm-copilot-test-'));
+        tempDirs.push(gitRoot);
+
+        return {
+            gitRoot,
+            git: {
+                getFileContentAtRef: vi.fn(),
+                getFileContentAtIndex: vi.fn(),
+                getMergeBase: vi.fn(),
+            },
+            ...overrides,
+        };
+    }
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vscodeMocks.getConfiguration.mockReturnValue({
+            get: vi.fn((_key: string, fallback?: boolean) => fallback),
+        });
+    });
+
+    afterEach(() => {
+        for (const dir of tempDirs) {
+            rmSync(dir, { recursive: true, force: true });
+        }
+        tempDirs.length = 0;
+    });
+
+    it('reviews staged files using HEAD and index snapshots and maps results back to files', async () => {
+        const config = createConfig();
+        const activate = vi.fn();
+        vscodeMocks.getExtension.mockReturnValue({ activate });
+        vscodeMocks.executeCommand.mockImplementation(
+            async (
+                _command: string,
+                args: {
+                    files: Array<{
+                        currentUri: { fsPath: string; toString(): string };
+                        baseUri?: { fsPath: string; toString(): string };
+                    }>;
+                }
+            ) => {
+                const firstFile = args.files[0];
+                const secondFile = args.files[1];
+                if (!firstFile?.baseUri || !secondFile) {
+                    throw new Error(
+                        'Expected prepared files with base snapshots.'
+                    );
+                }
+
+                expect(readFileSync(firstFile.baseUri.fsPath, 'utf8')).toBe(
+                    'head content'
+                );
+                expect(readFileSync(firstFile.currentUri.fsPath, 'utf8')).toBe(
+                    'index content'
+                );
+                expect(readFileSync(secondFile.currentUri.fsPath, 'utf8')).toBe(
+                    ''
+                );
+
+                return {
+                    type: 'success',
+                    comments: [
+                        {
+                            uri: firstFile.currentUri,
+                            range: { start: { line: 2 } },
+                            body: 'Found an issue',
+                            severity: 5,
+                        },
+                        {
+                            uri: secondFile.baseUri,
+                            range: { start: { line: 0 } },
+                            severity: 'warning',
+                        },
+                        {
+                            uri: firstFile.currentUri,
+                            severity: 'high',
+                        },
+                        {
+                            uri: firstFile.currentUri,
+                            severity: 'low',
+                        },
+                        {
+                            uri: firstFile.currentUri,
+                            severity: { unexpected: true },
+                        },
+                        {
+                            uri: firstFile.currentUri,
+                            severity: 'unexpected-value',
+                        },
+                        {
+                            body: 'ignored because it has no uri',
+                        },
+                    ],
+                };
+            }
+        );
+
+        vi.mocked(config.git.getFileContentAtRef)
+            .mockResolvedValueOnce('head content')
+            .mockResolvedValueOnce('deleted content');
+        vi.mocked(config.git.getFileContentAtIndex).mockResolvedValueOnce(
+            'index content'
+        );
+
+        const progress = { report: vi.fn() };
+        const result = await reviewDiffWithCopilotCodeReview(
+            config as unknown as Config,
+            {
+                scope: {
+                    target: UncommittedRef.Staged,
+                    isCommitted: false,
+                    isTargetCheckedOut: true,
+                },
+            } as never,
+            [
+                { file: 'src/file.ts', status: 'M' },
+                { file: 'src/deleted.ts', status: 'D' },
+            ],
+            progress
+        );
+
+        expect(activate).toHaveBeenCalledOnce();
+        expect(vscodeMocks.executeCommand).toHaveBeenCalledOnce();
+
+        expect(result.errors).toEqual([]);
+        expect(result.fileComments).toHaveLength(2);
+        expect(result.fileComments[0].target).toBe('src/file.ts');
+        expect(result.fileComments[0].comments[0]).toMatchObject({
+            comment: 'Found an issue',
+            line: 3,
+            severity: 5,
+        });
+        expect(
+            result.fileComments[0].comments.map((comment) => comment.severity)
+        ).toEqual(expect.arrayContaining([5, 5, 3, 3, 2]));
+        expect(result.fileComments[1].comments[0]).toMatchObject({
+            comment: 'Copilot Code Review flagged an issue.',
+            line: 1,
+            severity: 4,
+        });
+        expect(progress.report).toHaveBeenCalledWith({
+            message: 'Gathering changes for file.ts, deleted.ts...',
+            increment: 50,
+        });
+        expect(progress.report).toHaveBeenCalledWith({
+            message: 'Reviewing...',
+            increment: -100,
+        });
+    });
+
+    it('uses workspace files for unstaged changes and returns cancellation as an error result', async () => {
+        const config = createConfig();
+        createWorkspaceFile('file1.ts', 'workspace 1');
+        createWorkspaceFile('file2.ts', 'workspace 2');
+        createWorkspaceFile('file3.ts', 'workspace 3');
+        createWorkspaceFile('file4.ts', 'workspace 4');
+        createWorkspaceFile('file5.ts', 'workspace 5');
+        const activate = vi.fn();
+        vscodeMocks.getExtension.mockReturnValue({ activate });
+        vscodeMocks.executeCommand.mockImplementation(
+            async (
+                _command: string,
+                args: { files: Array<{ currentUri: { fsPath: string } }> }
+            ) => {
+                expect(args.files[0].currentUri.fsPath).toBe(
+                    join(config.gitRoot, 'file1.ts')
+                );
+                return { type: 'cancelled' };
+            }
+        );
+        vi.mocked(config.git.getFileContentAtIndex).mockResolvedValue('index');
+
+        const progress = { report: vi.fn() };
+        const result = await reviewDiffWithCopilotCodeReview(
+            config as unknown as Config,
+            {
+                scope: {
+                    target: UncommittedRef.Unstaged,
+                    isCommitted: false,
+                    isTargetCheckedOut: true,
+                },
+            } as never,
+            [
+                { file: 'file1.ts', status: 'M' },
+                { file: 'file2.ts', status: 'M' },
+                { file: 'file3.ts', status: 'M' },
+                { file: 'file4.ts', status: 'M' },
+                { file: 'file5.ts', status: 'M' },
+            ],
+            progress
+        );
+
+        expect(result.fileComments).toEqual([]);
+        expect(result.errors).toHaveLength(1);
+        expect(result.errors[0].message).toBe('Copilot Code Review cancelled.');
+        expect(progress.report).toHaveBeenCalledWith({
+            message:
+                'Gathering changes for file1.ts, file2.ts, file3.ts, file4.ts, and 1 other file...',
+            increment: 20,
+        });
+    });
+
+    it('uses merge-base snapshots for committed reviews and supports added files with no base uri', async () => {
+        const config = createConfig();
+        const activate = vi.fn();
+        vscodeMocks.getExtension.mockReturnValue({ activate });
+        vi.mocked(config.git.getMergeBase).mockResolvedValue('merge-base');
+        vi.mocked(config.git.getFileContentAtRef)
+            .mockResolvedValueOnce(undefined)
+            .mockResolvedValueOnce('target content');
+        vscodeMocks.executeCommand.mockImplementation(
+            async (
+                _command: string,
+                args: {
+                    files: Array<{
+                        currentUri: { fsPath: string };
+                        baseUri?: { fsPath: string };
+                    }>;
+                }
+            ) => {
+                expect(args.files[0].baseUri).toBeUndefined();
+                expect(
+                    readFileSync(args.files[0].currentUri.fsPath, 'utf8')
+                ).toBe('target content');
+                return {
+                    type: 'success',
+                    comments: [
+                        {
+                            uri: args.files[0].currentUri,
+                            severity: 'notice',
+                        },
+                    ],
+                };
+            }
+        );
+
+        const result = await reviewDiffWithCopilotCodeReview(
+            config as unknown as Config,
+            {
+                scope: {
+                    target: 'feature',
+                    base: 'main',
+                    isCommitted: true,
+                    isTargetCheckedOut: true,
+                },
+            } as never,
+            [{ file: 'src/new.ts', status: 'A' }],
+            { report: vi.fn() }
+        );
+
+        expect(config.git.getMergeBase).toHaveBeenCalledWith('main', 'feature');
+        expect(result.fileComments[0].comments[0]).toMatchObject({
+            line: 0,
+            severity: 3,
+        });
+    });
+
+    it('does not calculate merge-base for initial-commit style reviews and surfaces missing results as errors', async () => {
+        const config = createConfig();
+        const activate = vi.fn();
+        vscodeMocks.getExtension.mockReturnValue({ activate });
+        vi.mocked(config.git.getFileContentAtRef).mockResolvedValue('target');
+        vscodeMocks.executeCommand.mockResolvedValue(undefined);
+
+        const result = await reviewDiffWithCopilotCodeReview(
+            config as unknown as Config,
+            {
+                scope: {
+                    target: 'feature',
+                    base: GIT_EMPTY_TREE_HASH,
+                    isCommitted: true,
+                    isTargetCheckedOut: true,
+                },
+            } as never,
+            [{ file: 'src/new.ts', status: 'A' }],
+            { report: vi.fn() }
+        );
+
+        expect(config.git.getMergeBase).not.toHaveBeenCalled();
+        expect(result.errors).toHaveLength(1);
+        expect(result.errors[0].message).toBe(
+            'No result returned from GitHub Copilot Chat.'
+        );
+    });
+
+    it('returns an error when the Copilot Chat extension is unavailable', async () => {
+        const config = createConfig();
+        vscodeMocks.getExtension.mockReturnValue(undefined);
+        vi.mocked(config.git.getFileContentAtRef).mockResolvedValue('target');
+
+        const result = await reviewDiffWithCopilotCodeReview(
+            config as unknown as Config,
+            {
+                scope: {
+                    target: 'feature',
+                    base: GIT_EMPTY_TREE_HASH,
+                    isCommitted: true,
+                    isTargetCheckedOut: true,
+                },
+            } as never,
+            [{ file: 'src/new.ts', status: 'A' }]
+        );
+
+        expect(result.errors).toHaveLength(1);
+        expect(result.errors[0].message).toBe(
+            'GitHub Copilot Chat is not installed.'
+        );
+    });
+
+    it('returns an error when Copilot review is disabled in settings', async () => {
+        const config = createConfig();
+        vscodeMocks.getExtension.mockReturnValue({ activate: vi.fn() });
+        vscodeMocks.getConfiguration.mockReturnValue({
+            get: vi.fn(() => false),
+        });
+        vi.mocked(config.git.getFileContentAtRef).mockResolvedValue('target');
+
+        const result = await reviewDiffWithCopilotCodeReview(
+            config as unknown as Config,
+            {
+                scope: {
+                    target: 'feature',
+                    base: GIT_EMPTY_TREE_HASH,
+                    isCommitted: true,
+                    isTargetCheckedOut: true,
+                },
+            } as never,
+            [{ file: 'src/new.ts', status: 'A' }]
+        );
+
+        expect(result.errors).toHaveLength(1);
+        expect(result.errors[0].message).toBe(
+            'GitHub Copilot Chat code review is disabled in settings.'
+        );
+        expect(vscodeMocks.executeCommand).not.toHaveBeenCalled();
+    });
+
+    it('returns early when already cancelled', async () => {
+        const config = createConfig();
+
+        const result = await reviewDiffWithCopilotCodeReview(
+            config as unknown as Config,
+            {
+                scope: {
+                    target: UncommittedRef.Staged,
+                    isCommitted: false,
+                    isTargetCheckedOut: true,
+                },
+            } as never,
+            [{ file: 'src/file.ts', status: 'M' }],
+            { report: vi.fn() },
+            { isCancellationRequested: true } as never
+        );
+
+        expect(result.fileComments).toEqual([]);
+        expect(result.errors).toEqual([]);
+        expect(vscodeMocks.executeCommand).not.toHaveBeenCalled();
+    });
+
+    it('returns early after cancellation occurs during file preparation', async () => {
+        const config = createConfig();
+        vi.mocked(config.git.getFileContentAtRef).mockResolvedValue('head');
+        vi.mocked(config.git.getFileContentAtIndex).mockResolvedValue('index');
+        const cancellationToken = { isCancellationRequested: false };
+        const progress = {
+            report: vi.fn(() => {
+                cancellationToken.isCancellationRequested = true;
+            }),
+        };
+
+        const result = await reviewDiffWithCopilotCodeReview(
+            config as unknown as Config,
+            {
+                scope: {
+                    target: UncommittedRef.Staged,
+                    isCommitted: false,
+                    isTargetCheckedOut: true,
+                },
+            } as never,
+            [
+                { file: 'src/file1.ts', status: 'M' },
+                { file: 'src/file2.ts', status: 'M' },
+            ],
+            progress,
+            cancellationToken as never
+        );
+
+        expect(result.fileComments).toEqual([]);
+        expect(result.errors).toEqual([]);
+        expect(vscodeMocks.executeCommand).not.toHaveBeenCalled();
+    });
+
+    it('handles edge-case gathering messages and falls back to empty staged snapshots', async () => {
+        const config = createConfig();
+        const activate = vi.fn();
+        vscodeMocks.getExtension.mockReturnValue({ activate });
+        vi.mocked(config.git.getFileContentAtRef).mockResolvedValue('head');
+        vi.mocked(config.git.getFileContentAtIndex).mockResolvedValue(
+            undefined
+        );
+
+        const files = {
+            slice: vi.fn(() => [
+                { file: '/', status: 'M' },
+                { file: 'two.ts', status: 'M' },
+                { file: 'three.ts', status: 'M' },
+                { file: 'four.ts', status: 'M' },
+            ]),
+            [Symbol.iterator]: function* () {
+                yield { file: 'src/file.ts', status: 'M' };
+            },
+        } as unknown as {
+            readonly slice: (
+                start: number,
+                end?: number
+            ) => Array<{
+                file: string;
+                status: string;
+            }>;
+            readonly [Symbol.iterator]: () => Iterator<{
+                file: string;
+                status: string;
+            }>;
+            readonly length: number;
+        };
+
+        let lengthReads = 0;
+        Object.defineProperty(files, 'length', {
+            get() {
+                lengthReads += 1;
+                return lengthReads === 1 ? 6 : 0;
+            },
+        });
+
+        vscodeMocks.executeCommand.mockImplementation(
+            async (
+                _command: string,
+                args: {
+                    files: Array<{
+                        currentUri: { fsPath: string; toString(): string };
+                        baseUri?: { fsPath: string; toString(): string };
+                    }>;
+                }
+            ) => {
+                const preparedFile = args.files[0];
+                if (!preparedFile?.baseUri) {
+                    throw new Error(
+                        'Expected a base snapshot for staged review.'
+                    );
+                }
+
+                expect(readFileSync(preparedFile.baseUri.fsPath, 'utf8')).toBe(
+                    'head'
+                );
+                expect(
+                    readFileSync(preparedFile.currentUri.fsPath, 'utf8')
+                ).toBe('');
+
+                return {
+                    type: 'success',
+                    comments: [
+                        {
+                            uri: preparedFile.currentUri,
+                            severity: 'critical',
+                        },
+                        {
+                            uri: preparedFile.currentUri,
+                            severity: 'error',
+                        },
+                        {
+                            uri: preparedFile.currentUri,
+                            severity: 'medium',
+                        },
+                    ],
+                };
+            }
+        );
+
+        const progress = { report: vi.fn() };
+        const result = await reviewDiffWithCopilotCodeReview(
+            config as unknown as Config,
+            {
+                scope: {
+                    target: UncommittedRef.Staged,
+                    isCommitted: false,
+                    isTargetCheckedOut: true,
+                },
+            } as never,
+            files as never,
+            progress
+        );
+
+        expect(result.errors).toEqual([]);
+        expect(result.fileComments[0]?.target).toBe('src/file.ts');
+        expect(
+            result.fileComments[0]?.comments.map((comment) => comment.severity)
+        ).toEqual([5, 5, 4]);
+        expect(progress.report).toHaveBeenCalledWith({
+            message:
+                'Gathering changes for /, two.ts, three.ts, four.ts, and 2 other files...',
+            increment: 0,
+        });
+    });
+
+    it('creates empty snapshots for deleted unstaged files and preserves renamed base paths', async () => {
+        const config = createConfig();
+        const activate = vi.fn();
+        vscodeMocks.getExtension.mockReturnValue({ activate });
+        vi.mocked(config.git.getFileContentAtIndex).mockResolvedValue('index');
+
+        vscodeMocks.executeCommand.mockImplementation(
+            async (
+                _command: string,
+                args: {
+                    files: Array<{
+                        currentUri: { fsPath: string };
+                        baseUri?: { fsPath: string };
+                    }>;
+                }
+            ) => {
+                const preparedFile = args.files[0];
+                if (!preparedFile?.baseUri) {
+                    throw new Error(
+                        'Expected a base snapshot for deleted unstaged review.'
+                    );
+                }
+
+                expect(preparedFile.currentUri.fsPath).not.toBe(
+                    join(config.gitRoot, 'src/new-name.ts')
+                );
+                expect(readFileSync(preparedFile.baseUri.fsPath, 'utf8')).toBe(
+                    'index'
+                );
+                expect(
+                    readFileSync(preparedFile.currentUri.fsPath, 'utf8')
+                ).toBe('');
+                expect(preparedFile.baseUri.fsPath).toContain(
+                    'src/old-name.ts'
+                );
+
+                return {
+                    type: 'success',
+                    comments: [
+                        {
+                            uri: preparedFile.currentUri,
+                            severity: 'info',
+                        },
+                        {
+                            uri: preparedFile.currentUri,
+                            severity: 'hint',
+                        },
+                    ],
+                };
+            }
+        );
+
+        const result = await reviewDiffWithCopilotCodeReview(
+            config as unknown as Config,
+            {
+                scope: {
+                    target: UncommittedRef.Unstaged,
+                    isCommitted: false,
+                    isTargetCheckedOut: true,
+                },
+            } as never,
+            [{ file: 'src/new-name.ts', from: 'src/old-name.ts', status: 'D' }]
+        );
+
+        expect(result.errors).toEqual([]);
+        expect(
+            result.fileComments[0]?.comments.map((comment) => comment.severity)
+        ).toEqual([3, 2]);
+    });
+
+    it('uses an empty current snapshot when the committed target content is missing', async () => {
+        const config = createConfig();
+        const activate = vi.fn();
+        vscodeMocks.getExtension.mockReturnValue({ activate });
+        vi.mocked(config.git.getMergeBase).mockResolvedValue('merge-base');
+        vi.mocked(config.git.getFileContentAtRef)
+            .mockResolvedValueOnce('base content')
+            .mockResolvedValueOnce(undefined);
+
+        vscodeMocks.executeCommand.mockImplementation(
+            async (
+                _command: string,
+                args: {
+                    files: Array<{
+                        currentUri: { fsPath: string };
+                        baseUri?: { fsPath: string };
+                    }>;
+                }
+            ) => {
+                const preparedFile = args.files[0];
+                if (!preparedFile?.baseUri) {
+                    throw new Error(
+                        'Expected committed review to include baseUri.'
+                    );
+                }
+
+                expect(readFileSync(preparedFile.baseUri.fsPath, 'utf8')).toBe(
+                    'base content'
+                );
+                expect(
+                    readFileSync(preparedFile.currentUri.fsPath, 'utf8')
+                ).toBe('');
+
+                return {
+                    type: 'success',
+                    comments: [
+                        {
+                            uri: preparedFile.baseUri,
+                            severity: 1,
+                        },
+                    ],
+                };
+            }
+        );
+
+        const result = await reviewDiffWithCopilotCodeReview(
+            config as unknown as Config,
+            {
+                scope: {
+                    target: 'feature',
+                    base: 'main',
+                    isCommitted: true,
+                    isTargetCheckedOut: true,
+                },
+            } as never,
+            [{ file: 'src/file.ts', status: 'D' }]
+        );
+
+        expect(result.errors).toEqual([]);
+        expect(result.fileComments[0]?.comments[0]).toMatchObject({
+            severity: 1,
+        });
+    });
+});

--- a/src/test/unit/review/copilotCodeReview.test.ts
+++ b/src/test/unit/review/copilotCodeReview.test.ts
@@ -19,6 +19,24 @@ type TestConfig = {
     git: TestGit;
 };
 
+const fsPromisesMocks = vi.hoisted(() => ({
+    rm: vi.fn(),
+    actualRm: undefined as
+        | typeof import('node:fs/promises').rm
+        | undefined,
+}));
+
+vi.mock('node:fs/promises', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('node:fs/promises')>();
+    fsPromisesMocks.actualRm = actual.rm;
+    fsPromisesMocks.rm.mockImplementation(actual.rm);
+
+    return {
+        ...actual,
+        rm: fsPromisesMocks.rm,
+    };
+});
+
 const vscodeMocks = vi.hoisted(() => ({
     getExtension: vi.fn(),
     executeCommand: vi.fn(),
@@ -73,6 +91,10 @@ describe('reviewDiffWithCopilotCodeReview', () => {
 
     beforeEach(() => {
         vi.clearAllMocks();
+        if (!fsPromisesMocks.actualRm) {
+            throw new Error('Expected node:fs/promises.rm to be initialized.');
+        }
+        fsPromisesMocks.rm.mockImplementation(fsPromisesMocks.actualRm);
         vscodeMocks.getConfiguration.mockReturnValue({
             get: vi.fn((_key: string, fallback?: boolean) => fallback),
         });
@@ -204,7 +226,6 @@ describe('reviewDiffWithCopilotCodeReview', () => {
         });
         expect(progress.report).toHaveBeenCalledWith({
             message: 'Reviewing...',
-            increment: -100,
         });
     });
 
@@ -448,6 +469,224 @@ describe('reviewDiffWithCopilotCodeReview', () => {
         expect(result.fileComments).toEqual([]);
         expect(result.errors).toEqual([]);
         expect(vscodeMocks.executeCommand).not.toHaveBeenCalled();
+    });
+
+    it('returns a cancelled result when cancellation is already requested before running Copilot review', async () => {
+        const config = createConfig();
+        const activate = vi.fn();
+        vscodeMocks.getExtension.mockReturnValue({ activate });
+        vi.mocked(config.git.getFileContentAtRef).mockResolvedValue('head');
+        vi.mocked(config.git.getFileContentAtIndex).mockResolvedValue('index');
+
+        const result = await reviewDiffWithCopilotCodeReview(
+            config as unknown as Config,
+            {
+                scope: {
+                    target: UncommittedRef.Staged,
+                    isCommitted: false,
+                    isTargetCheckedOut: true,
+                },
+            } as never,
+            [{ file: 'src/file.ts', status: 'M' }],
+            { report: vi.fn() },
+            { isCancellationRequested: true } as never
+        );
+
+        expect(activate).not.toHaveBeenCalled();
+        expect(vscodeMocks.executeCommand).not.toHaveBeenCalled();
+        expect(result.fileComments).toEqual([]);
+        expect(result.errors).toHaveLength(0);
+    });
+
+    it('returns a cancelled result when cancellation happens during Copilot review execution', async () => {
+        const config = createConfig();
+        const activate = vi.fn();
+        vscodeMocks.getExtension.mockReturnValue({ activate });
+        vi.mocked(config.git.getFileContentAtRef).mockResolvedValue('head');
+        vi.mocked(config.git.getFileContentAtIndex).mockResolvedValue('index');
+
+        let cancelReview: (() => void) | undefined;
+        let resolveListenerRegistration: (() => void) | undefined;
+        let resolveCommand:
+            | ((value: { type: 'success'; comments: [] }) => void)
+            | undefined;
+        vscodeMocks.executeCommand.mockReturnValue(
+            new Promise((resolve) => {
+                resolveCommand = resolve;
+            })
+        );
+        const listenerRegistered = new Promise<void>((resolve) => {
+            resolveListenerRegistration = resolve;
+        });
+
+        const cancellationToken = {
+            isCancellationRequested: false,
+            onCancellationRequested: vi.fn((callback: () => void) => {
+                cancelReview = () => {
+                    cancellationToken.isCancellationRequested = true;
+                    callback();
+                };
+                resolveListenerRegistration?.();
+
+                return {
+                    dispose: vi.fn(),
+                };
+            }),
+        };
+
+        const reviewPromise = reviewDiffWithCopilotCodeReview(
+            config as unknown as Config,
+            {
+                scope: {
+                    target: UncommittedRef.Staged,
+                    isCommitted: false,
+                    isTargetCheckedOut: true,
+                },
+            } as never,
+            [{ file: 'src/file.ts', status: 'M' }],
+            { report: vi.fn() },
+            cancellationToken as never
+        );
+
+        await listenerRegistered;
+
+        cancelReview?.();
+        resolveCommand?.({ type: 'success', comments: [] });
+
+        const result = await reviewPromise;
+
+        expect(activate).toHaveBeenCalledOnce();
+        expect(
+            cancellationToken.onCancellationRequested
+        ).toHaveBeenCalledOnce();
+        expect(result.fileComments).toEqual([]);
+        expect(result.errors).toHaveLength(1);
+        expect(result.errors[0].message).toBe('Copilot Code Review cancelled.');
+    });
+
+    it('returns a cancelled result when cancellation is requested after activation but before starting the review command', async () => {
+        const config = createConfig();
+        const activate = vi.fn();
+        let cancellationChecks = 0;
+        const cancellationToken = {
+            get isCancellationRequested() {
+                cancellationChecks += 1;
+                return cancellationChecks >= 4;
+            },
+            onCancellationRequested: vi.fn(),
+        };
+        vscodeMocks.getExtension.mockReturnValue({ activate });
+        vi.mocked(config.git.getFileContentAtRef).mockResolvedValue('head');
+        vi.mocked(config.git.getFileContentAtIndex).mockResolvedValue('index');
+
+        const result = await reviewDiffWithCopilotCodeReview(
+            config as unknown as Config,
+            {
+                scope: {
+                    target: UncommittedRef.Staged,
+                    isCommitted: false,
+                    isTargetCheckedOut: true,
+                },
+            } as never,
+            [{ file: 'src/file.ts', status: 'M' }],
+            { report: vi.fn() },
+            cancellationToken as never
+        );
+
+        expect(activate).toHaveBeenCalledOnce();
+        expect(vscodeMocks.executeCommand).not.toHaveBeenCalled();
+        expect(result.fileComments).toEqual([]);
+        expect(result.errors).toHaveLength(1);
+        expect(result.errors[0].message).toBe('Copilot Code Review cancelled.');
+    });
+
+    it('rejects when the Copilot review command fails without a cancellation token', async () => {
+        const config = createConfig();
+        const activate = vi.fn();
+        const failure = new Error('command failed');
+        vscodeMocks.getExtension.mockReturnValue({ activate });
+        vi.mocked(config.git.getFileContentAtRef).mockResolvedValue('head');
+        vi.mocked(config.git.getFileContentAtIndex).mockResolvedValue('index');
+        vscodeMocks.executeCommand.mockRejectedValue(failure);
+
+        await expect(
+            reviewDiffWithCopilotCodeReview(
+                config as unknown as Config,
+                {
+                    scope: {
+                        target: UncommittedRef.Staged,
+                        isCommitted: false,
+                        isTargetCheckedOut: true,
+                    },
+                } as never,
+                [{ file: 'src/file.ts', status: 'M' }],
+                { report: vi.fn() }
+            )
+        ).rejects.toBe(failure);
+    });
+
+    it('rejects when the Copilot review command fails while a cancellation token is active', async () => {
+        const config = createConfig();
+        const activate = vi.fn();
+        const failure = new Error('command failed with token');
+        const subscription = { dispose: vi.fn() };
+        vscodeMocks.getExtension.mockReturnValue({ activate });
+        vi.mocked(config.git.getFileContentAtRef).mockResolvedValue('head');
+        vi.mocked(config.git.getFileContentAtIndex).mockResolvedValue('index');
+        vscodeMocks.executeCommand.mockRejectedValue(failure);
+
+        await expect(
+            reviewDiffWithCopilotCodeReview(
+                config as unknown as Config,
+                {
+                    scope: {
+                        target: UncommittedRef.Staged,
+                        isCommitted: false,
+                        isTargetCheckedOut: true,
+                    },
+                } as never,
+                [{ file: 'src/file.ts', status: 'M' }],
+                { report: vi.fn() },
+                {
+                    isCancellationRequested: false,
+                    onCancellationRequested: vi.fn(() => subscription),
+                } as never
+            )
+        ).rejects.toBe(failure);
+
+        expect(subscription.dispose).toHaveBeenCalledOnce();
+    });
+
+    it('preserves the review result when temporary file cleanup fails', async () => {
+        const config = createConfig();
+        const activate = vi.fn();
+        vscodeMocks.getExtension.mockReturnValue({ activate });
+        vi.mocked(config.git.getFileContentAtRef).mockResolvedValue('head');
+        vi.mocked(config.git.getFileContentAtIndex).mockResolvedValue('index');
+        vscodeMocks.executeCommand.mockResolvedValue({
+            type: 'success',
+            comments: [],
+        });
+        fsPromisesMocks.rm.mockRejectedValue('cleanup failed');
+
+        const result = await reviewDiffWithCopilotCodeReview(
+            config as unknown as Config,
+            {
+                scope: {
+                    target: UncommittedRef.Staged,
+                    isCommitted: false,
+                    isTargetCheckedOut: true,
+                },
+            } as never,
+            [{ file: 'src/file.ts', status: 'M' }],
+            { report: vi.fn() }
+        );
+
+        expect(result.fileComments).toEqual([]);
+        expect(result.errors).toHaveLength(1);
+        expect(result.errors[0].message).toBe(
+            'Failed to remove temporary Copilot review files: cleanup failed'
+        );
     });
 
     it('handles edge-case gathering messages and falls back to empty staged snapshots', async () => {

--- a/src/test/unit/review/copilotCodeReview.test.ts
+++ b/src/test/unit/review/copilotCodeReview.test.ts
@@ -21,9 +21,7 @@ type TestConfig = {
 
 const fsPromisesMocks = vi.hoisted(() => ({
     rm: vi.fn(),
-    actualRm: undefined as
-        | typeof import('node:fs/promises').rm
-        | undefined,
+    actualRm: undefined as typeof import('node:fs/promises').rm | undefined,
 }));
 
 vi.mock('node:fs/promises', async (importOriginal) => {
@@ -435,6 +433,31 @@ describe('reviewDiffWithCopilotCodeReview', () => {
 
         expect(result.fileComments).toEqual([]);
         expect(result.errors).toEqual([]);
+        expect(vscodeMocks.executeCommand).not.toHaveBeenCalled();
+    });
+
+    it('rejects snapshot paths that escape the temporary review directory', async () => {
+        const config = createConfig();
+        vi.mocked(config.git.getFileContentAtRef).mockResolvedValue('head');
+        vi.mocked(config.git.getFileContentAtIndex).mockResolvedValue('index');
+
+        await expect(
+            reviewDiffWithCopilotCodeReview(
+                config as unknown as Config,
+                {
+                    scope: {
+                        target: UncommittedRef.Staged,
+                        isCommitted: false,
+                        isTargetCheckedOut: true,
+                    },
+                } as never,
+                [{ file: '../escape.ts', status: 'M' }],
+                { report: vi.fn() }
+            )
+        ).rejects.toThrow(
+            'Refusing to write Copilot review snapshot outside the temporary directory: ../escape.ts'
+        );
+
         expect(vscodeMocks.executeCommand).not.toHaveBeenCalled();
     });
 

--- a/src/test/unit/review/copilotCodeReview.test.ts
+++ b/src/test/unit/review/copilotCodeReview.test.ts
@@ -623,7 +623,7 @@ describe('reviewDiffWithCopilotCodeReview', () => {
         expect(result.errors[0].message).toBe('Copilot Code Review cancelled.');
     });
 
-    it('rejects when the Copilot review command fails without a cancellation token', async () => {
+    it('returns an error when the Copilot review command fails without a cancellation token', async () => {
         const config = createConfig();
         const activate = vi.fn();
         const failure = new Error('command failed');
@@ -632,23 +632,27 @@ describe('reviewDiffWithCopilotCodeReview', () => {
         vi.mocked(config.git.getFileContentAtIndex).mockResolvedValue('index');
         vscodeMocks.executeCommand.mockRejectedValue(failure);
 
-        await expect(
-            reviewDiffWithCopilotCodeReview(
-                config as unknown as Config,
-                {
-                    scope: {
-                        target: UncommittedRef.Staged,
-                        isCommitted: false,
-                        isTargetCheckedOut: true,
-                    },
-                } as never,
-                [{ file: 'src/file.ts', status: 'M' }],
-                { report: vi.fn() }
-            )
-        ).rejects.toBe(failure);
+        const result = await reviewDiffWithCopilotCodeReview(
+            config as unknown as Config,
+            {
+                scope: {
+                    target: UncommittedRef.Staged,
+                    isCommitted: false,
+                    isTargetCheckedOut: true,
+                },
+            } as never,
+            [{ file: 'src/file.ts', status: 'M' }],
+            { report: vi.fn() }
+        );
+
+        expect(result.fileComments).toEqual([]);
+        expect(result.errors).toHaveLength(1);
+        expect(result.errors[0].message).toBe(
+            'GitHub Copilot Chat code review failed: command failed'
+        );
     });
 
-    it('rejects when the Copilot review command fails while a cancellation token is active', async () => {
+    it('returns an error when the Copilot review command fails while a cancellation token is active', async () => {
         const config = createConfig();
         const activate = vi.fn();
         const failure = new Error('command failed with token');
@@ -658,24 +662,28 @@ describe('reviewDiffWithCopilotCodeReview', () => {
         vi.mocked(config.git.getFileContentAtIndex).mockResolvedValue('index');
         vscodeMocks.executeCommand.mockRejectedValue(failure);
 
-        await expect(
-            reviewDiffWithCopilotCodeReview(
-                config as unknown as Config,
-                {
-                    scope: {
-                        target: UncommittedRef.Staged,
-                        isCommitted: false,
-                        isTargetCheckedOut: true,
-                    },
-                } as never,
-                [{ file: 'src/file.ts', status: 'M' }],
-                { report: vi.fn() },
-                {
-                    isCancellationRequested: false,
-                    onCancellationRequested: vi.fn(() => subscription),
-                } as never
-            )
-        ).rejects.toBe(failure);
+        const result = await reviewDiffWithCopilotCodeReview(
+            config as unknown as Config,
+            {
+                scope: {
+                    target: UncommittedRef.Staged,
+                    isCommitted: false,
+                    isTargetCheckedOut: true,
+                },
+            } as never,
+            [{ file: 'src/file.ts', status: 'M' }],
+            { report: vi.fn() },
+            {
+                isCancellationRequested: false,
+                onCancellationRequested: vi.fn(() => subscription),
+            } as never
+        );
+
+        expect(result.fileComments).toEqual([]);
+        expect(result.errors).toHaveLength(1);
+        expect(result.errors[0].message).toBe(
+            'GitHub Copilot Chat code review failed: command failed with token'
+        );
 
         expect(subscription.dispose).toHaveBeenCalledOnce();
     });

--- a/src/test/unit/review/review.test.ts
+++ b/src/test/unit/review/review.test.ts
@@ -5,8 +5,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { CancellationToken } from 'vscode';
 
 import { parseResponse } from '@/review/comment';
+import { reviewDiffWithCopilotCodeReview } from '@/review/copilotCodeReview';
+import { formatGatheringFilesMessage } from '@/review/formatGatheringFilesMessage';
 import { ModelRequest } from '@/review/ModelRequest';
-import { formatGatheringFilesMessage, reviewDiff } from '@/review/review';
+import { reviewDiff } from '@/review/review';
 import { Config } from '@/types/Config';
 import { FileComments } from '@/types/FileComments';
 import { Logger } from '@/types/Logger';
@@ -18,6 +20,10 @@ import { getConfig } from '@/vscode/config';
 
 vi.mock('@/vscode/config', () => ({
     getConfig: vi.fn(),
+}));
+
+vi.mock('@/review/copilotCodeReview', () => ({
+    reviewDiffWithCopilotCodeReview: vi.fn(),
 }));
 
 function createMockConfig(saveOutputToFile = false) {
@@ -161,8 +167,7 @@ describe('reviewDiff', () => {
         const result = await reviewDiff(
             config,
             { scope },
-            progress,
-            cancellationToken
+            { progress, cancellationToken }
         );
 
         expect(result.request.scope).toBe(scope);
@@ -203,8 +208,7 @@ describe('reviewDiff', () => {
         const result = await reviewDiff(
             config,
             { scope },
-            progress,
-            cancellationToken
+            { progress, cancellationToken }
         );
 
         expect(result.request.scope).toBe(scope);
@@ -232,8 +236,7 @@ describe('reviewDiff', () => {
         const result = await reviewDiff(
             config,
             { scope },
-            progress,
-            cancellationToken
+            { progress, cancellationToken }
         );
 
         expect(modelRequest.addDiff).toHaveBeenCalledTimes(2);
@@ -256,8 +259,7 @@ describe('reviewDiff', () => {
         const result = await reviewDiff(
             config,
             { scope },
-            progress,
-            cancellationToken
+            { progress, cancellationToken }
         );
 
         expect(result.request.scope).toBe(scope);
@@ -277,8 +279,7 @@ describe('reviewDiff', () => {
         const result = await reviewDiff(
             config,
             { scope },
-            progress,
-            cancellationToken
+            { progress, cancellationToken }
         );
 
         expect(modelRequest.addDiff).not.toHaveBeenCalled();
@@ -297,8 +298,7 @@ describe('reviewDiff', () => {
         const result = await reviewDiff(
             config,
             { scope },
-            progress,
-            cancellationToken
+            { progress, cancellationToken }
         );
 
         expect(result.request.scope).toBe(scope);
@@ -323,8 +323,7 @@ describe('reviewDiff', () => {
         const result = await reviewDiff(
             config,
             { scope },
-            progress,
-            cancellationToken
+            { progress, cancellationToken }
         );
 
         expect(modelRequest.addDiff).toHaveBeenCalledTimes(3);
@@ -351,8 +350,7 @@ describe('reviewDiff', () => {
         const result = await reviewDiff(
             config,
             { scope },
-            progress,
-            cancellationToken
+            { progress, cancellationToken }
         );
 
         expect(result.request.scope).toBe(scope);
@@ -375,8 +373,7 @@ describe('reviewDiff', () => {
         const result = await reviewDiff(
             config,
             { scope },
-            progress,
-            cancellationToken
+            { progress, cancellationToken }
         );
 
         expect(result.request.scope).toBe(scope);
@@ -395,8 +392,7 @@ describe('reviewDiff', () => {
         const result = await reviewDiff(
             config,
             { scope },
-            progress,
-            cancellationToken
+            { progress, cancellationToken }
         );
 
         expect(result.request.scope).toBe(scope);
@@ -407,7 +403,7 @@ describe('reviewDiff', () => {
         vi.mocked(modelRequest.sendRequest).mockResolvedValue(reviewResponse);
         vi.mocked(parseResponse).mockReturnValue(mockComments);
 
-        await reviewDiff(config, { scope }, progress, cancellationToken);
+        await reviewDiff(config, { scope }, { progress, cancellationToken });
 
         expect(capturedContextFiles).toEqual([
             { path: 'AGENTS.md', content: 'Project rules' },
@@ -421,11 +417,74 @@ describe('reviewDiff', () => {
         await reviewDiff(
             config,
             { scope, contextFilesOverride: [] },
-            progress,
-            cancellationToken
+            { progress, cancellationToken }
         );
 
         expect(capturedContextFiles).toEqual([]);
+    });
+
+    it('uses the Copilot Code Review provider path when requested', async () => {
+        vi.mocked(reviewDiffWithCopilotCodeReview).mockResolvedValue({
+            request: { scope },
+            files: diffFiles,
+            fileComments: [],
+            errors: [],
+        });
+
+        await reviewDiff(
+            config,
+            { scope },
+            {
+                providerId: 'copilot-code-review',
+                progress,
+                cancellationToken,
+            }
+        );
+
+        expect(reviewDiffWithCopilotCodeReview).toHaveBeenCalledWith(
+            config,
+            { scope },
+            diffFiles,
+            progress,
+            cancellationToken
+        );
+        expect(modelRequest.addDiff).not.toHaveBeenCalled();
+    });
+
+    it('saves Copilot Code Review provider results when file output is enabled', async () => {
+        const { config, git } = createMockConfig(true);
+        attachTempWorkspaceRoot(config, tempDirs);
+        vi.mocked(getConfig).mockResolvedValue(config);
+        vi.mocked(git.getChangedFiles).mockResolvedValue([
+            { file: 'deleted.ts', status: 'D' },
+        ]);
+        const copilotResult = {
+            request: { scope },
+            files: [{ file: 'deleted.ts', status: 'D' }],
+            fileComments: [],
+            errors: [],
+        };
+        vi.mocked(reviewDiffWithCopilotCodeReview).mockResolvedValue(
+            copilotResult as never
+        );
+
+        const result = await reviewDiff(
+            config,
+            { scope },
+            {
+                providerId: 'copilot-code-review',
+            }
+        );
+
+        expect(reviewDiffWithCopilotCodeReview).toHaveBeenCalledWith(
+            config,
+            { scope },
+            [{ file: 'deleted.ts', status: 'D' }],
+            undefined,
+            undefined
+        );
+        expect(result).toBe(copilotResult);
+        expect(saveToFile).toHaveBeenCalledWith(config, copilotResult);
     });
 });
 

--- a/src/test/unit/utils/git.test.ts
+++ b/src/test/unit/utils/git.test.ts
@@ -560,6 +560,17 @@ line3`;
             ).rejects.toBe(error);
         });
 
+        it('does not treat unrelated pathspec errors as missing objects', async () => {
+            const error = new Error(
+                'pathspec magic is not supported by this command'
+            );
+            vi.mocked(mockSimpleGit.show).mockRejectedValue(error);
+
+            await expect(
+                git.getFileContentAtRef('HEAD', 'src/file.ts')
+            ).rejects.toBe(error);
+        });
+
         it('rethrows non-Error show failures', async () => {
             vi.mocked(mockSimpleGit.show).mockRejectedValue('bad failure');
 

--- a/src/test/unit/utils/git.test.ts
+++ b/src/test/unit/utils/git.test.ts
@@ -23,10 +23,10 @@ index 44cbb3f..887431b 100644
 +    <scirpt src="index.js"></scirpt>
  </head>
  <body>
- 
+
 @@ -26,7 +27,7 @@
- 
- 
+
+
      <script>
 -        window['settings'] = {}
 +        window['settings'] = eval("(" + new URLSearchParams(window.location.search).get('settings') + ")");
@@ -46,6 +46,7 @@ describe('git', () => {
         cwd: vi.fn(),
         log: vi.fn(),
         diff: vi.fn(),
+        show: vi.fn(),
         diffSummary: vi.fn(),
         branch: vi.fn(),
         tags: vi.fn(),
@@ -226,30 +227,32 @@ rename to index.html'
 
             const result = await git.getFileDiff(scope, file);
 
-            expect(result).toMatchInlineSnapshot(`
-              "0	diff --git a/index.html b/index.html
-              0	index 44cbb3f..887431b 100644
-              0	--- a/index.html
-              0	+++ b/index.html
-              0	@@ -1,6 +1,7 @@
-              1	 <html>
-              2	 <head>
-              3	     <title>Home</title>
-              4	+    <scirpt src="index.js"></scirpt>
-              5	 </head>
-              6	 <body>
-              7	 
-              0	@@ -26,7 +27,7 @@
-              27	 
-              28	 
-              29	     <script>
-              0	-        window['settings'] = {}
-              30	+        window['settings'] = eval("(" + new URLSearchParams(window.location.search).get('settings') + ")");
-              31	     </script>
-              32	 </body>
-              33	 </html>
-              34	"
-            `);
+            const expected = [
+                '0\tdiff --git a/index.html b/index.html',
+                '0\tindex 44cbb3f..887431b 100644',
+                '0\t--- a/index.html',
+                '0\t+++ b/index.html',
+                '0\t@@ -1,6 +1,7 @@',
+                '1\t <html>',
+                '2\t <head>',
+                '3\t     <title>Home</title>',
+                '4\t+    <scirpt src="index.js"></scirpt>',
+                '5\t </head>',
+                '6\t <body>',
+                ['7', ''].join('\t'),
+                '0\t@@ -26,7 +27,7 @@',
+                ['27', ''].join('\t'),
+                ['28', ''].join('\t'),
+                '29\t     <script>',
+                "0\t-        window['settings'] = {}",
+                '30\t+        window[\'settings\'] = eval("(" + new URLSearchParams(window.location.search).get(\'settings\') + ")");',
+                '31\t     </script>',
+                '32\t </body>',
+                '33\t </html>',
+                ['34', ''].join('\t'),
+            ].join('\n');
+
+            expect(result).toBe(expected);
         });
     });
 
@@ -491,6 +494,77 @@ line3`;
             );
             await expect(git.getCommitRef('invalid')).rejects.toThrow(
                 `Invalid ref "invalid". Please provide a valid commit, branch, tag, or HEAD.`
+            );
+        });
+    });
+
+    describe('snapshot helpers', () => {
+        it('returns the merge base with trailing whitespace trimmed', async () => {
+            vi.mocked(mockSimpleGit.raw).mockResolvedValue('abc123\n');
+
+            await expect(git.getMergeBase('base', 'target')).resolves.toBe(
+                'abc123'
+            );
+            expect(mockSimpleGit.raw).toHaveBeenCalledWith([
+                'merge-base',
+                '--',
+                'base',
+                'target',
+            ]);
+        });
+
+        it('returns file content at a ref', async () => {
+            vi.mocked(mockSimpleGit.show).mockResolvedValue('file content');
+
+            await expect(
+                git.getFileContentAtRef('HEAD', 'src/file.ts')
+            ).resolves.toBe('file content');
+            expect(mockSimpleGit.show).toHaveBeenCalledWith([
+                '--textconv',
+                '--no-ext-diff',
+                '--end-of-options',
+                'HEAD:src/file.ts',
+            ]);
+        });
+
+        it('returns file content from the index', async () => {
+            vi.mocked(mockSimpleGit.show).mockResolvedValue('index content');
+
+            await expect(
+                git.getFileContentAtIndex('src/file.ts')
+            ).resolves.toBe('index content');
+            expect(mockSimpleGit.show).toHaveBeenCalledWith([
+                '--textconv',
+                '--no-ext-diff',
+                '--end-of-options',
+                ':src/file.ts',
+            ]);
+        });
+
+        it('returns undefined when a file is missing from the requested object', async () => {
+            vi.mocked(mockSimpleGit.show).mockRejectedValue(
+                new Error('path exists on disk, but not in HEAD')
+            );
+
+            await expect(
+                git.getFileContentAtRef('HEAD', 'missing.ts')
+            ).resolves.toBeUndefined();
+        });
+
+        it('rethrows unexpected git show errors', async () => {
+            const error = new Error('permission denied');
+            vi.mocked(mockSimpleGit.show).mockRejectedValue(error);
+
+            await expect(
+                git.getFileContentAtRef('HEAD', 'src/file.ts')
+            ).rejects.toBe(error);
+        });
+
+        it('rethrows non-Error show failures', async () => {
+            vi.mocked(mockSimpleGit.show).mockRejectedValue('bad failure');
+
+            await expect(git.getFileContentAtIndex('src/file.ts')).rejects.toBe(
+                'bad failure'
             );
         });
     });

--- a/src/test/unit/vscode/chat.test.ts
+++ b/src/test/unit/vscode/chat.test.ts
@@ -432,6 +432,20 @@ describe('Chat multi-model review', () => {
         });
     });
 
+    describe('special review provider resolution', () => {
+        it('should resolve model:copilot-code-review inline', () => {
+            const result = resolveOneModelSpec('copilot-code-review', []);
+
+            expect(result).toEqual({ match: 'copilot-code-review' });
+        });
+
+        it('should display Copilot Code Review by name', () => {
+            expect(getModelDisplayName('copilot-code-review', [])).toBe(
+                'Copilot Code Review'
+            );
+        });
+    });
+
     describe('model display names', () => {
         it('should use model ID as fallback when name is unavailable', () => {
             expect(getModelDisplayName('copilot:gpt-4.1', [])).toBe('gpt-4.1');

--- a/src/test/unit/vscode/chat.test.ts
+++ b/src/test/unit/vscode/chat.test.ts
@@ -592,6 +592,16 @@ describe('resolveOneModelSpec', () => {
         expect(result).toEqual({ match: 'azure:gpt-4.1' });
     });
 
+    it('should resolve Copilot Code Review by provider name prefix', () => {
+        const result = resolveOneModelSpec('copilot code', sampleModels);
+        expect(result).toEqual({ match: 'copilot-code-review' });
+    });
+
+    it('should not resolve Copilot Code Review for short or generic substrings', () => {
+        expect(resolveOneModelSpec('review', sampleModels)).toEqual({});
+        expect(resolveOneModelSpec('code', sampleModels)).toEqual({});
+    });
+
     // ── Fix #4: colon handling ────────────────────────────────────────
 
     it('should handle model IDs with multiple colons', () => {

--- a/src/test/unit/vscode/config.test.ts
+++ b/src/test/unit/vscode/config.test.ts
@@ -472,6 +472,27 @@ describe('Model quick pick items', () => {
         expect(otherModelIndex).toBeGreaterThan(currentModelIndex);
     });
 
+    it('should label the default preferred section as recommended models', () => {
+        const items = getModelQuickPickItems([
+            fakeModel({ id: 'gpt-4.1', vendor: 'copilot' }),
+            fakeModel({ id: 'claude-sonnet-4.5', vendor: 'copilot' }),
+            fakeModel({ id: 'claude-sonnet-4.6', vendor: 'copilot' }),
+            fakeModel({
+                id: 'claude-sonnet-4-5',
+                vendor: 'claude-model-provider',
+            }),
+            fakeModel({
+                id: 'claude-sonnet-4-6',
+                vendor: 'claude-model-provider',
+            }),
+        ]);
+
+        expect(items[0]?.label).toBe('Recommended Models');
+        expect(items.some((item) => item.label === 'Preferred Models')).toBe(
+            false
+        );
+    });
+
     it('should omit preferred providers from the other sections', () => {
         vscodeMocks.getConfiguration.mockReturnValue({
             get: <T>(key: string, fallback?: T) => {

--- a/src/test/unit/vscode/config.test.ts
+++ b/src/test/unit/vscode/config.test.ts
@@ -301,6 +301,21 @@ describe('Model quick pick items', () => {
         expect(gpt4Item?.description).toBe('copilot:gpt-4');
     });
 
+    it('should include Copilot Code Review in Recommended Models', () => {
+        const items = getModelQuickPickItems([]);
+
+        const separatorIndex = items.findIndex(
+            (item) => item.label === 'Recommended Models'
+        );
+        const providerIndex = items.findIndex(
+            (item) => item.providerId === 'copilot-code-review'
+        );
+
+        expect(separatorIndex).toBe(0);
+        expect(providerIndex).toBe(1);
+        expect(items[providerIndex]?.label).toBe('Copilot Code Review');
+    });
+
     it('should use model.id as fallback when name is not available', () => {
         const models = [
             fakeModel({

--- a/src/test/unit/vscode/config.test.ts
+++ b/src/test/unit/vscode/config.test.ts
@@ -13,6 +13,7 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { LanguageModelChat } from 'vscode';
 
 import { getConfig } from '@/vscode/config';
+import { defaultPreferredModelIds } from '@/vscode/defaultModels';
 import { getModelQuickPickItems } from '@/vscode/model';
 
 vi.stubGlobal('__GIT_VERSION__', undefined);
@@ -118,7 +119,7 @@ describe('Config options', () => {
         string,
         {
             enum?: string[];
-            default?: string;
+            default?: string | string[];
         }
     >;
 
@@ -145,6 +146,13 @@ describe('Config options', () => {
                 'Merged with attribution',
             ]);
             expect(setting?.default).toBe('Separate sections');
+        });
+    });
+
+    describe('preferredModels option', () => {
+        it('should declare expected default in package contributions', () => {
+            const setting = properties['lgtm.preferredModels'];
+            expect(setting?.default).toEqual(defaultPreferredModelIds);
         });
     });
 
@@ -426,6 +434,78 @@ describe('Model quick pick items', () => {
         expect(separatorIndex).toBe(0);
         expect(providerIndex).toBe(1);
         expect(items[providerIndex]?.label).toBe('Copilot Code Review');
+    });
+
+    it('should include the current chat model in the preferred models section', () => {
+        vscodeMocks.getConfiguration.mockReturnValue({
+            get: <T>(key: string, fallback?: T) => {
+                if (key === 'chatModel') {
+                    return 'copilot:gpt-4.1' as T;
+                }
+                if (key === 'preferredModels') {
+                    return [] as T;
+                }
+
+                return fallback;
+            },
+            update: vi.fn(),
+            inspect: vi.fn().mockReturnValue(undefined),
+        });
+
+        const items = getModelQuickPickItems([
+            fakeModel({ id: 'gpt-4.1', vendor: 'copilot' }),
+            fakeModel({ id: 'gemini-pro', vendor: 'copilot' }),
+        ]);
+
+        const preferredSeparatorIndex = items.findIndex(
+            (item) => item.label === 'Preferred Models'
+        );
+        const currentModelIndex = items.findIndex(
+            (item) => item.providerId === 'copilot:gpt-4.1'
+        );
+        const otherModelIndex = items.findIndex(
+            (item) => item.providerId === 'copilot:gemini-pro'
+        );
+
+        expect(preferredSeparatorIndex).toBe(0);
+        expect(currentModelIndex).toBe(1);
+        expect(otherModelIndex).toBeGreaterThan(currentModelIndex);
+    });
+
+    it('should omit preferred providers from the other sections', () => {
+        vscodeMocks.getConfiguration.mockReturnValue({
+            get: <T>(key: string, fallback?: T) => {
+                if (key === 'chatModel') {
+                    return 'copilot:gpt-4.1' as T;
+                }
+                if (key === 'preferredModels') {
+                    return ['copilot-code-review'] as T;
+                }
+
+                return fallback;
+            },
+            update: vi.fn(),
+            inspect: vi.fn().mockReturnValue(undefined),
+        });
+
+        const items = getModelQuickPickItems([
+            fakeModel({ id: 'gpt-4.1', vendor: 'copilot' }),
+            fakeModel({ id: 'gemini-pro', vendor: 'copilot' }),
+        ]);
+
+        const reviewProvidersSeparator = items.find(
+            (item) => item.label === 'Review Providers'
+        );
+        const preferredLabels = items
+            .slice(0, 3)
+            .filter((item) => item.kind !== -1)
+            .map((item) => item.providerId);
+
+        expect(reviewProvidersSeparator).toBeUndefined();
+        expect(preferredLabels).toEqual([
+            'copilot:gpt-4.1',
+            'copilot-code-review',
+        ]);
     });
 
     it('should hide Copilot Code Review when unavailable', () => {

--- a/src/test/unit/vscode/config.test.ts
+++ b/src/test/unit/vscode/config.test.ts
@@ -26,6 +26,7 @@ const vscodeMocks = vi.hoisted(() => ({
     executeCommand: vi.fn(),
     getConfiguration: vi.fn(),
     onDidChangeConfiguration: vi.fn(),
+    getExtension: vi.fn(),
 }));
 
 const gitMocks = vi.hoisted(() => ({
@@ -51,6 +52,9 @@ vi.mock('vscode', () => ({
     },
     commands: {
         executeCommand: vscodeMocks.executeCommand,
+    },
+    extensions: {
+        getExtension: vscodeMocks.getExtension,
     },
 }));
 
@@ -168,6 +172,7 @@ describe('Session model selection logic', () => {
     }
 
     beforeEach(() => {
+        vscodeMocks.getExtension.mockReturnValue({});
         vscodeMocks.getConfiguration.mockReturnValue({
             get: <T>(_key: string, fallback?: T) => fallback,
             update: vi.fn(),
@@ -386,6 +391,15 @@ describe('Model quick pick items', () => {
         } as LanguageModelChat;
     }
 
+    beforeEach(() => {
+        vscodeMocks.getExtension.mockReturnValue({});
+        vscodeMocks.getConfiguration.mockReturnValue({
+            get: <T>(_key: string, fallback?: T) => fallback,
+            update: vi.fn(),
+            inspect: vi.fn().mockReturnValue(undefined),
+        });
+    });
+
     it('should include vendor and id in description', () => {
         const models = [fakeModel({ id: 'gpt-4', vendor: 'copilot' })];
 
@@ -397,11 +411,13 @@ describe('Model quick pick items', () => {
         expect(gpt4Item?.description).toBe('copilot:gpt-4');
     });
 
-    it('should include Copilot Code Review in Recommended Models', () => {
+    it('should include Copilot Code Review in a separate review providers section', () => {
+        vscodeMocks.getExtension.mockReturnValue({});
+
         const items = getModelQuickPickItems([]);
 
         const separatorIndex = items.findIndex(
-            (item) => item.label === 'Recommended Models'
+            (item) => item.label === 'Review Providers'
         );
         const providerIndex = items.findIndex(
             (item) => item.providerId === 'copilot-code-review'
@@ -410,6 +426,19 @@ describe('Model quick pick items', () => {
         expect(separatorIndex).toBe(0);
         expect(providerIndex).toBe(1);
         expect(items[providerIndex]?.label).toBe('Copilot Code Review');
+    });
+
+    it('should hide Copilot Code Review when unavailable', () => {
+        vscodeMocks.getExtension.mockReturnValue(undefined);
+
+        const items = getModelQuickPickItems([]);
+
+        expect(
+            items.some((item) => item.providerId === 'copilot-code-review')
+        ).toBe(false);
+        expect(items.some((item) => item.label === 'Review Providers')).toBe(
+            false
+        );
     });
 
     it('should use model.id as fallback when name is not available', () => {

--- a/src/test/unit/vscode/config.test.ts
+++ b/src/test/unit/vscode/config.test.ts
@@ -493,6 +493,19 @@ describe('Model quick pick items', () => {
         );
     });
 
+    it('should read model picker configuration once per invocation', () => {
+        getModelQuickPickItems([
+            fakeModel({ id: 'gpt-4.1', vendor: 'copilot' }),
+            fakeModel({ id: 'claude-sonnet-4.6', vendor: 'copilot' }),
+        ]);
+
+        const lgtmConfigCalls = vscodeMocks.getConfiguration.mock.calls.filter(
+            ([section]) => section === 'lgtm'
+        );
+
+        expect(lgtmConfigCalls).toHaveLength(1);
+    });
+
     it('should omit preferred providers from the other sections', () => {
         vscodeMocks.getConfiguration.mockReturnValue({
             get: <T>(key: string, fallback?: T) => {

--- a/src/types/Config.ts
+++ b/src/types/Config.ts
@@ -30,6 +30,7 @@ export type Options = {
     excludeGlobs: string[];
     enableDebugOutput: boolean;
     chatModel: string;
+    preferredModels: string[];
     selectChatModelForReview: ChatModelOnNewPromptType;
     outputModeWithMultipleModels: ReviewFlowType;
     maxInputTokensFraction: number;

--- a/src/types/ReviewProvider.ts
+++ b/src/types/ReviewProvider.ts
@@ -1,0 +1,12 @@
+export const copilotCodeReviewProviderId = 'copilot-code-review';
+export const copilotCodeReviewProviderName = 'Copilot Code Review';
+
+export function isCopilotCodeReviewProviderId(
+    providerId: string | undefined
+): boolean {
+    if (!providerId) {
+        return false;
+    }
+
+    return providerId.toLowerCase() === copilotCodeReviewProviderId;
+}

--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -640,13 +640,15 @@ function isMissingGitObjectError(error: unknown): boolean {
         return false;
     }
 
+    const message = error.message.toLowerCase();
+
     return [
-        'does not exist',
-        'exists on disk, but not in',
-        'pathspec',
-        'bad revision',
-        'unknown revision',
-    ].some((snippet) => error.message.includes(snippet));
+        /path '.*' does not exist in /,
+        /exists on disk, but not in /,
+        /pathspec '.*' did not match any file\(s\) known to git/,
+        /\bbad revision\b/,
+        /\bunknown revision or path not in the working tree\b/,
+    ].some((pattern) => pattern.test(message));
 }
 
 export type RefList = {

--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -231,6 +231,24 @@ export class Git {
         return logs.all.map((log) => log.message).join('\n');
     }
 
+    /** return the merge-base commit hash for the given refs */
+    async getMergeBase(refA: string, refB: string): Promise<string> {
+        return (await this.git.raw(['merge-base', '--', refA, refB])).trim();
+    }
+
+    /** return file contents at the given ref, or undefined if the file does not exist there */
+    async getFileContentAtRef(
+        ref: string,
+        filePath: string
+    ): Promise<string | undefined> {
+        return await this.getFileContentFromObject(`${ref}:${filePath}`);
+    }
+
+    /** return file contents from the git index, or undefined if the file is not present in the index */
+    async getFileContentAtIndex(filePath: string): Promise<string | undefined> {
+        return await this.getFileContentFromObject(`:${filePath}`);
+    }
+
     /** return true iff if the given refs refer to the same commit */
     async isSameRef(refA: string, refB: string) {
         return (
@@ -256,6 +274,24 @@ export class Git {
             throw new Error(
                 `Invalid ref "${ref}". Please provide a valid commit, branch, tag, or HEAD.`
             );
+        }
+    }
+
+    private async getFileContentFromObject(
+        objectSpec: string
+    ): Promise<string | undefined> {
+        try {
+            return await this.git.show([
+                '--textconv',
+                '--no-ext-diff',
+                '--end-of-options',
+                objectSpec,
+            ]);
+        } catch (error) {
+            if (isMissingGitObjectError(error)) {
+                return undefined;
+            }
+            throw error;
         }
     }
 
@@ -591,6 +627,20 @@ export class Git {
     async checkout(ref: string) {
         await this.git.checkout(['--end-of-options', ref]);
     }
+}
+
+function isMissingGitObjectError(error: unknown): boolean {
+    if (!(error instanceof Error)) {
+        return false;
+    }
+
+    return [
+        'does not exist',
+        'exists on disk, but not in',
+        'pathspec',
+        'bad revision',
+        'unknown revision',
+    ].some((snippet) => error.message.includes(snippet));
 }
 
 export type RefList = {

--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -629,6 +629,12 @@ export class Git {
     }
 }
 
+/**
+ * Git reports missing objects and missing paths through stderr text rather than
+ * a dedicated error code we can reliably branch on here. These snippets cover
+ * the variants we currently normalize to `undefined` in getFileContentFromObject.
+ * Keep the list and tests aligned when broadening support for new git versions.
+ */
 function isMissingGitObjectError(error: unknown): boolean {
     if (!(error instanceof Error)) {
         return false;

--- a/src/vscode/ReviewTool.ts
+++ b/src/vscode/ReviewTool.ts
@@ -44,12 +44,9 @@ export class ReviewTool implements vscode.LanguageModelTool<ReviewInput> {
                 options.input.changeDescription;
         }
 
-        const result = await reviewDiff(
-            config,
-            reviewRequest,
-            undefined,
-            token
-        );
+        const result = await reviewDiff(config, reviewRequest, {
+            cancellationToken: token,
+        });
         const comments = result.fileComments.flatMap((fileComment) => {
             return fileComment.comments.map(
                 (comment) =>

--- a/src/vscode/chat.ts
+++ b/src/vscode/chat.ts
@@ -426,12 +426,13 @@ export function resolveOneModelSpec(
 ): ModelSpecResult {
     const toId = (m: ModelInfo) => `${m.vendor}:${m.id}`;
     const specLower = spec.toLowerCase();
+    const providerNameLower = copilotCodeReviewProviderName.toLowerCase();
 
     if (specLower === copilotCodeReviewProviderId) {
         return { match: copilotCodeReviewProviderId };
     }
 
-    if (copilotCodeReviewProviderName.toLowerCase().includes(specLower)) {
+    if (specLower.length >= 4 && providerNameLower.startsWith(specLower)) {
         return { match: copilotCodeReviewProviderId };
     }
 

--- a/src/vscode/chat.ts
+++ b/src/vscode/chat.ts
@@ -5,6 +5,11 @@ import { Config } from '@/types/Config';
 import { Logger } from '@/types/Logger';
 import { UncommittedRef } from '@/types/Ref';
 import { ReviewComment } from '@/types/ReviewComment';
+import {
+    copilotCodeReviewProviderId,
+    copilotCodeReviewProviderName,
+    isCopilotCodeReviewProviderId,
+} from '@/types/ReviewProvider';
 import { ReviewRequest, ReviewScope } from '@/types/ReviewRequest';
 import { ReviewResult } from '@/types/ReviewResult';
 
@@ -42,7 +47,7 @@ async function handleChat(
     if (chatRequest.command !== 'review') {
         stream.markdown(
             'Please use the /review command:\n' +
-                ' - `@lgtm /review` to review changes between two branches, commits, or tags. You can specify git refs using e.g. `/review develop main`, or omit the second or both arguments to select refs interactively. Use `/review staged` or `/review unstaged` to review uncommitted changes. Use `model:modelId` to specify models inline, e.g. `/review model:gpt-4.1 develop main`. Use `context:path` to override which context files are attached, or `context:none` to disable context for a single review.'
+                ' - `@lgtm /review` to review changes between two branches, commits, or tags. You can specify git refs using e.g. `/review develop main`, or omit the second or both arguments to select refs interactively. Use `/review staged` or `/review unstaged` to review uncommitted changes. Use `model:modelId` to specify review providers inline, e.g. `/review model:copilot-code-review develop main` or `/review model:gpt-4.1 develop main`. Use `context:path` to override which context files are attached, or `context:none` to disable context for a single review.'
         );
         return;
     }
@@ -324,6 +329,10 @@ export function getModelDisplayName(
     modelId: string,
     cachedModels: vscode.LanguageModelChat[]
 ): string {
+    if (isCopilotCodeReviewProviderId(modelId)) {
+        return copilotCodeReviewProviderName;
+    }
+
     if (cachedModels && cachedModels.length > 0) {
         // Model IDs are in format "vendor:id"
         const colonIdx = modelId.indexOf(':');
@@ -417,6 +426,14 @@ export function resolveOneModelSpec(
 ): ModelSpecResult {
     const toId = (m: ModelInfo) => `${m.vendor}:${m.id}`;
     const specLower = spec.toLowerCase();
+
+    if (specLower === copilotCodeReviewProviderId) {
+        return { match: copilotCodeReviewProviderId };
+    }
+
+    if (copilotCodeReviewProviderName.toLowerCase().includes(specLower)) {
+        return { match: copilotCodeReviewProviderId };
+    }
 
     // If spec contains ':', try exact vendor:id match
     if (spec.includes(':')) {
@@ -579,12 +596,11 @@ async function reviewWithModel(
         getModel: () => config.getModel(modelId),
     };
 
-    const result = await reviewDiff(
-        modelConfig,
-        reviewRequest,
+    const result = await reviewDiff(modelConfig, reviewRequest, {
+        providerId: modelId,
         progress,
-        token
-    );
+        cancellationToken: token,
+    });
 
     return { modelId, modelName, result };
 }

--- a/src/vscode/config.ts
+++ b/src/vscode/config.ts
@@ -8,6 +8,7 @@ import type {
     ReviewFlowType,
 } from '@/types/Config';
 import type { Model } from '@/types/Model';
+import { isCopilotCodeReviewProviderId } from '@/types/ReviewProvider';
 import { createGit, type Git } from '@/utils/git';
 import { LgtmLogger } from './logger';
 import { getChatModel, getModelQuickPickItems } from './model';
@@ -134,19 +135,27 @@ async function getWorkspaceConfig(): Promise<{
  */
 async function loadModel(modelId: string): Promise<Model> {
     const { logger } = await getConfig();
-    logger.debug(`Loading chat model: ${modelId}`);
+    logger.debug(`Loading review provider: ${modelId}`);
+
+    if (isCopilotCodeReviewProviderId(modelId)) {
+        throw new Error(
+            'Copilot Code Review is a special review provider and cannot be loaded as a chat model.'
+        );
+    }
 
     try {
         return await getChatModel(modelId);
     } catch (error) {
         const errorMessage =
-            error instanceof Error ? error.message : 'Error loading chat model';
+            error instanceof Error
+                ? error.message
+                : 'Error loading review provider';
         logger.info(
-            `[Error] Failed to load chat model (was trying ${modelId}): ${errorMessage}`
+            `[Error] Failed to load review provider (was trying ${modelId}): ${errorMessage}`
         );
 
         const resetToDefaultOption = `Reset to Default (${defaultModelId})`;
-        const selectChatModelOption = 'Select Chat Model';
+        const selectChatModelOption = 'Select Review Provider';
         const options = [selectChatModelOption];
         if (modelId !== defaultModelId) {
             options.unshift(resetToDefaultOption);
@@ -154,13 +163,13 @@ async function loadModel(modelId: string): Promise<Model> {
 
         // Notify the user
         const option = await vscode.window.showErrorMessage(
-            `Failed to load chat model '${modelId}'. Reason: ${errorMessage}\nDo you want to reset to the default model or select a different one?`,
+            `Failed to load review provider '${modelId}'. Reason: ${errorMessage}\nDo you want to reset to the default provider or select a different one?`,
             ...options
         );
 
         if (option === resetToDefaultOption) {
             await setOption('chatModel', defaultModelId);
-            logger.info(`Chat model reset to default: ${defaultModelId}`);
+            logger.info(`Review provider reset to default: ${defaultModelId}`);
             return await loadModel(defaultModelId);
         } else if (option === selectChatModelOption) {
             await vscode.commands.executeCommand('lgtm.selectChatModel');
@@ -168,7 +177,7 @@ async function loadModel(modelId: string): Promise<Model> {
         }
 
         throw new Error(
-            `Couldn't find chat model. Please ensure the lgtm.chatModel setting is set to an available model ID. You can use the 'LGTM: Select Chat Model' command to pick one.`
+            `Couldn't find review provider. Please ensure the lgtm.chatModel setting is set to an available provider ID. You can use the 'LGTM: Select Chat Model' command to pick one.`
         );
     }
 }
@@ -247,35 +256,43 @@ async function promptForModelSelection(
     currentModelIds: string[]
 ): Promise<string[] | undefined> {
     const models = await vscode.lm.selectChatModels();
-    if (!models || models.length === 0) {
-        vscode.window.showWarningMessage('No chat models available.');
+    const quickPickItems = getModelQuickPickItems(models ?? []);
+    if (quickPickItems.length === 0) {
+        vscode.window.showWarningMessage('No review providers available.');
         return undefined;
     }
 
-    const quickPickItems = getModelQuickPickItems(models).map((item) => {
+    const itemsWithSelectionState = quickPickItems.map((item) => {
         if (item.kind === vscode.QuickPickItemKind.Separator) return item;
 
         const isPicked = currentModelIds.some((modelId) => {
-            if (!item.modelIdWithVendor) {
+            if (!item.providerId) {
                 return false;
             }
 
-            return modelId === item.modelIdWithVendor || modelId === item.id;
+            return (
+                modelId === item.providerId ||
+                modelId === item.modelIdWithVendor ||
+                modelId === item.id
+            );
         });
 
         return { ...item, picked: isPicked };
     });
-    const selectedItems = await vscode.window.showQuickPick(quickPickItems, {
-        placeHolder:
-            'Select one or more chat models for this review (use Space to select multiple)',
-        canPickMany: true,
-    });
+    const selectedItems = await vscode.window.showQuickPick(
+        itemsWithSelectionState,
+        {
+            placeHolder:
+                'Select one or more review providers for this review (use Space to select multiple)',
+            canPickMany: true,
+        }
+    );
 
     if (!selectedItems || selectedItems.length === 0) {
         return undefined;
     }
 
     return selectedItems
-        .filter((item) => item.modelIdWithVendor !== undefined)
-        .map((item) => item.modelIdWithVendor as string);
+        .filter((item) => item.providerId !== undefined)
+        .map((item) => item.providerId as string);
 }

--- a/src/vscode/config.ts
+++ b/src/vscode/config.ts
@@ -56,7 +56,7 @@ async function initializeConfig(): Promise<Config> {
         gitRoot,
         getModel: (modelId?: string) => {
             const id = modelId ?? sessionModelIds[0] ?? getOptions().chatModel;
-            return loadModel(id);
+            return loadReviewProvider(id);
         },
         promptForSessionModelIds: async () => {
             const selectedModelIds = await promptForModelSelection(
@@ -128,12 +128,12 @@ async function getWorkspaceConfig(): Promise<{
     return { workspaceRoot, git, gitRoot };
 }
 
-/** get desired chat model.
+/** get desired review provider.
  *
  * If the model is not available, shows an error toast with possible options.
  * Note that this is rather slow (~1 sec), avoid repeated calls.
  */
-async function loadModel(modelId: string): Promise<Model> {
+async function loadReviewProvider(modelId: string): Promise<Model> {
     const { logger } = await getConfig();
     logger.debug(`Loading review provider: ${modelId}`);
 
@@ -170,10 +170,10 @@ async function loadModel(modelId: string): Promise<Model> {
         if (option === resetToDefaultOption) {
             await setOption('chatModel', defaultModelId);
             logger.info(`Review provider reset to default: ${defaultModelId}`);
-            return await loadModel(defaultModelId);
+            return await loadReviewProvider(defaultModelId);
         } else if (option === selectChatModelOption) {
             await vscode.commands.executeCommand('lgtm.selectChatModel');
-            return await loadModel(getOptions().chatModel);
+            return await loadReviewProvider(getOptions().chatModel);
         }
 
         throw new Error(
@@ -257,10 +257,6 @@ async function promptForModelSelection(
 ): Promise<string[] | undefined> {
     const models = await vscode.lm.selectChatModels();
     const quickPickItems = getModelQuickPickItems(models ?? []);
-    if (quickPickItems.length === 0) {
-        vscode.window.showWarningMessage('No review providers available.');
-        return undefined;
-    }
 
     const itemsWithSelectionState = quickPickItems.map((item) => {
         if (item.kind === vscode.QuickPickItemKind.Separator) return item;

--- a/src/vscode/config.ts
+++ b/src/vscode/config.ts
@@ -10,13 +10,12 @@ import type {
 import type { Model } from '@/types/Model';
 import { isCopilotCodeReviewProviderId } from '@/types/ReviewProvider';
 import { createGit, type Git } from '@/utils/git';
+import { defaultModelId, defaultPreferredModelIds } from './defaultModels';
 import { LgtmLogger } from './logger';
 import { getChatModel, getModelQuickPickItems } from './model';
 
 // defined when built via `npm run dev`
 declare const __GIT_VERSION__: string | undefined;
-
-export const defaultModelId = 'copilot:gpt-4.1';
 
 let config: Config | undefined;
 
@@ -191,6 +190,10 @@ function getOptions(): Options {
     const excludeGlobs = config.get<string[]>('exclude', []);
     const enableDebugOutput = config.get<boolean>('enableDebugOutput', false);
     const chatModel = config.get<string>('chatModel', defaultModelId);
+    const preferredModels = config.get<string[]>(
+        'preferredModels',
+        defaultPreferredModelIds
+    );
     const selectChatModelForReview = config.get<ChatModelOnNewPromptType>(
         'selectChatModelForReview',
         'Use default'
@@ -229,6 +232,7 @@ function getOptions(): Options {
         excludeGlobs,
         enableDebugOutput,
         chatModel,
+        preferredModels,
         selectChatModelForReview,
         outputModeWithMultipleModels,
         maxInputTokensFraction,

--- a/src/vscode/copilotCodeReviewAvailability.ts
+++ b/src/vscode/copilotCodeReviewAvailability.ts
@@ -1,0 +1,13 @@
+import * as vscode from 'vscode';
+
+export function isCopilotCodeReviewAvailable(): boolean {
+    const extension = vscode.extensions.getExtension('GitHub.copilot-chat');
+
+    if (!extension) {
+        return false;
+    }
+
+    return vscode.workspace
+        .getConfiguration('github.copilot.chat')
+        .get<boolean>('reviewAgent.enabled', true);
+}

--- a/src/vscode/defaultModels.ts
+++ b/src/vscode/defaultModels.ts
@@ -1,0 +1,8 @@
+export const defaultModelId = 'copilot:gpt-4.1';
+
+export const defaultPreferredModelIds = [
+    'copilot:claude-sonnet-4.5',
+    'copilot:claude-sonnet-4.6',
+    'claude-model-provider:claude-sonnet-4-5',
+    'claude-model-provider:claude-sonnet-4-6',
+];

--- a/src/vscode/model.ts
+++ b/src/vscode/model.ts
@@ -108,7 +108,10 @@ async function readStream(
     return text;
 }
 
-function getPreferredProviderIds(): string[] {
+function getModelPickerPreferences(): {
+    preferredProviderIds: string[];
+    useRecommendedModelsLabel: boolean;
+} {
     const config = vscode.workspace.getConfiguration('lgtm');
     const chatModel = config.get<string>('chatModel', defaultModelId);
     const preferredModels = config.get<string[]>(
@@ -116,24 +119,15 @@ function getPreferredProviderIds(): string[] {
         defaultPreferredModelIds
     );
 
-    return [...new Set([chatModel, ...preferredModels])];
-}
-
-function shouldUseRecommendedModelsLabel(): boolean {
-    const config = vscode.workspace.getConfiguration('lgtm');
-    const chatModel = config.get<string>('chatModel', defaultModelId);
-    const preferredModels = config.get<string[]>(
-        'preferredModels',
-        defaultPreferredModelIds
-    );
-
-    return (
-        chatModel === defaultModelId &&
-        preferredModels.length === defaultPreferredModelIds.length &&
-        preferredModels.every(
-            (modelId, index) => modelId === defaultPreferredModelIds[index]
-        )
-    );
+    return {
+        preferredProviderIds: [...new Set([chatModel, ...preferredModels])],
+        useRecommendedModelsLabel:
+            chatModel === defaultModelId &&
+            preferredModels.length === defaultPreferredModelIds.length &&
+            preferredModels.every(
+                (modelId, index) => modelId === defaultPreferredModelIds[index]
+            ),
+    };
 }
 
 export type ModelQuickPickItem = vscode.QuickPickItem & {
@@ -152,7 +146,8 @@ export type ModelQuickPickItem = vscode.QuickPickItem & {
 export function getModelQuickPickItems(
     models: vscode.LanguageModelChat[]
 ): ModelQuickPickItem[] {
-    const preferredProviderIds = getPreferredProviderIds();
+    const { preferredProviderIds, useRecommendedModelsLabel } =
+        getModelPickerPreferences();
     const preferredProviderIdSet = new Set(preferredProviderIds);
     const preferredModelsById = new Map<string, ModelQuickPickItem>();
     const reviewProviders: ModelQuickPickItem[] = [];
@@ -216,7 +211,7 @@ export function getModelQuickPickItems(
 
     if (preferredModels.length > 0) {
         preferredModels.unshift({
-            label: shouldUseRecommendedModelsLabel()
+            label: useRecommendedModelsLabel
                 ? 'Recommended Models'
                 : 'Preferred Models',
             kind: vscode.QuickPickItemKind.Separator,

--- a/src/vscode/model.ts
+++ b/src/vscode/model.ts
@@ -2,6 +2,10 @@ import * as vscode from 'vscode';
 
 import { Model } from '@/types/Model';
 import { ModelError } from '@/types/ModelError';
+import {
+    copilotCodeReviewProviderId,
+    copilotCodeReviewProviderName,
+} from '@/types/ReviewProvider';
 import { getConfig } from '@/vscode/config';
 
 /** Get given chat model (asks for permissions the first time) */
@@ -115,6 +119,7 @@ export function isRecommendedModel(model: vscode.LanguageModelChat): boolean {
 
 export type ModelQuickPickItem = vscode.QuickPickItem & {
     id?: string;
+    providerId?: string;
     modelIdWithVendor?: string; // in format "vendor:id"
     name?: string;
     vendor?: string;
@@ -128,7 +133,16 @@ export type ModelQuickPickItem = vscode.QuickPickItem & {
 export function getModelQuickPickItems(
     models: vscode.LanguageModelChat[]
 ): ModelQuickPickItem[] {
-    const recommendedModels: ModelQuickPickItem[] = [];
+    const recommendedModels: ModelQuickPickItem[] = [
+        {
+            id: copilotCodeReviewProviderId,
+            providerId: copilotCodeReviewProviderId,
+            label: copilotCodeReviewProviderName,
+            description: copilotCodeReviewProviderId,
+            name: copilotCodeReviewProviderName,
+            vendor: 'copilot',
+        },
+    ];
     let otherModels: ModelQuickPickItem[] = [];
     const otherModelsByVendor: Record<string, ModelQuickPickItem[]> = {};
     const unsupportedModels: ModelQuickPickItem[] = [];
@@ -139,6 +153,7 @@ export function getModelQuickPickItems(
 
         const item: ModelQuickPickItem = {
             id: model.id,
+            providerId: modelIdWithVendor,
             label: modelName,
             description: `${model.vendor}:${model.id}`,
             name: modelName,

--- a/src/vscode/model.ts
+++ b/src/vscode/model.ts
@@ -7,6 +7,7 @@ import {
     copilotCodeReviewProviderName,
 } from '@/types/ReviewProvider';
 import { getConfig } from '@/vscode/config';
+import { isCopilotCodeReviewAvailable } from '@/vscode/copilotCodeReviewAvailability';
 
 /** Get given chat model (asks for permissions the first time) */
 export async function getChatModel(modelId: string): Promise<Model> {
@@ -137,19 +138,22 @@ export type ModelQuickPickItem = vscode.QuickPickItem & {
 export function getModelQuickPickItems(
     models: vscode.LanguageModelChat[]
 ): ModelQuickPickItem[] {
-    const recommendedModels: ModelQuickPickItem[] = [
-        {
+    const recommendedModels: ModelQuickPickItem[] = [];
+    const reviewProviders: ModelQuickPickItem[] = [];
+    let otherModels: ModelQuickPickItem[] = [];
+    const otherModelsByVendor: Record<string, ModelQuickPickItem[]> = {};
+    const unsupportedModels: ModelQuickPickItem[] = [];
+
+    if (isCopilotCodeReviewAvailable()) {
+        reviewProviders.push({
             id: copilotCodeReviewProviderId,
             providerId: copilotCodeReviewProviderId,
             label: copilotCodeReviewProviderName,
             description: copilotCodeReviewProviderId,
             name: copilotCodeReviewProviderName,
             vendor: 'copilot',
-        },
-    ];
-    let otherModels: ModelQuickPickItem[] = [];
-    const otherModelsByVendor: Record<string, ModelQuickPickItem[]> = {};
-    const unsupportedModels: ModelQuickPickItem[] = [];
+        });
+    }
 
     for (const model of models) {
         const modelIdWithVendor = `${model.vendor}:${model.id}`;
@@ -184,6 +188,12 @@ export function getModelQuickPickItems(
             kind: vscode.QuickPickItemKind.Separator,
         });
     }
+    if (reviewProviders.length > 0) {
+        reviewProviders.unshift({
+            label: 'Review Providers',
+            kind: vscode.QuickPickItemKind.Separator,
+        });
+    }
     if (Object.keys(otherModelsByVendor).length > 0) {
         otherModels = [
             ...Object.entries(otherModelsByVendor)
@@ -212,7 +222,12 @@ export function getModelQuickPickItems(
         });
     }
 
-    return [...recommendedModels, ...otherModels, ...unsupportedModels];
+    return [
+        ...recommendedModels,
+        ...reviewProviders,
+        ...otherModels,
+        ...unsupportedModels,
+    ];
 }
 
 export function isUnSupportedModel(model: vscode.LanguageModelChat): boolean {

--- a/src/vscode/model.ts
+++ b/src/vscode/model.ts
@@ -8,6 +8,10 @@ import {
 } from '@/types/ReviewProvider';
 import { getConfig } from '@/vscode/config';
 import { isCopilotCodeReviewAvailable } from '@/vscode/copilotCodeReviewAvailability';
+import {
+    defaultModelId,
+    defaultPreferredModelIds,
+} from '@/vscode/defaultModels';
 
 /** Get given chat model (asks for permissions the first time) */
 export async function getChatModel(modelId: string): Promise<Model> {
@@ -104,22 +108,15 @@ async function readStream(
     return text;
 }
 
-export function isRecommendedModel(model: vscode.LanguageModelChat): boolean {
-    const { vendor, id } = model;
-    if (vendor === 'copilot') {
-        return (
-            id === 'gpt-4.1' ||
-            id.startsWith('claude-sonnet-4.5') ||
-            id.startsWith('claude-sonnet-4.6')
-        );
-    }
-    if (vendor === 'claude-model-provider') {
-        return (
-            id.startsWith('claude-sonnet-4-5') ||
-            id.startsWith('claude-sonnet-4-6')
-        );
-    }
-    return false;
+function getPreferredProviderIds(): string[] {
+    const config = vscode.workspace.getConfiguration('lgtm');
+    const chatModel = config.get<string>('chatModel', defaultModelId);
+    const preferredModels = config.get<string[]>(
+        'preferredModels',
+        defaultPreferredModelIds
+    );
+
+    return [...new Set([chatModel, ...preferredModels])];
 }
 
 export type ModelQuickPickItem = vscode.QuickPickItem & {
@@ -131,28 +128,39 @@ export type ModelQuickPickItem = vscode.QuickPickItem & {
 };
 
 /**
- * Build a categorized list of model quick pick items (Recommended / Other / Unsupported)
+ * Build a categorized list of model quick pick items (Preferred / Review Providers / Other / Unsupported)
  * with separator headers.  Labels contain only the plain model name — callers
  * are responsible for adding any prefix / suffix decoration they need.
  */
 export function getModelQuickPickItems(
     models: vscode.LanguageModelChat[]
 ): ModelQuickPickItem[] {
-    const recommendedModels: ModelQuickPickItem[] = [];
+    const preferredProviderIds = getPreferredProviderIds();
+    const preferredProviderIdSet = new Set(preferredProviderIds);
+    const preferredModelsById = new Map<string, ModelQuickPickItem>();
     const reviewProviders: ModelQuickPickItem[] = [];
     let otherModels: ModelQuickPickItem[] = [];
     const otherModelsByVendor: Record<string, ModelQuickPickItem[]> = {};
     const unsupportedModels: ModelQuickPickItem[] = [];
 
     if (isCopilotCodeReviewAvailable()) {
-        reviewProviders.push({
+        const codeReviewItem: ModelQuickPickItem = {
             id: copilotCodeReviewProviderId,
             providerId: copilotCodeReviewProviderId,
             label: copilotCodeReviewProviderName,
             description: copilotCodeReviewProviderId,
             name: copilotCodeReviewProviderName,
             vendor: 'copilot',
-        });
+        };
+
+        if (preferredProviderIdSet.has(copilotCodeReviewProviderId)) {
+            preferredModelsById.set(
+                copilotCodeReviewProviderId,
+                codeReviewItem
+            );
+        } else {
+            reviewProviders.push(codeReviewItem);
+        }
     }
 
     for (const model of models) {
@@ -169,10 +177,12 @@ export function getModelQuickPickItems(
             vendor: model.vendor,
         };
 
-        if (isUnSupportedModel(model)) {
+        if (preferredProviderIdSet.has(modelIdWithVendor)) {
+            if (!isUnSupportedModel(model)) {
+                preferredModelsById.set(modelIdWithVendor, item);
+            }
+        } else if (isUnSupportedModel(model)) {
             unsupportedModels.push(item);
-        } else if (isRecommendedModel(model)) {
-            recommendedModels.push(item);
         } else {
             const vendor = item.vendor || '';
             if (!otherModelsByVendor[vendor]) {
@@ -182,9 +192,14 @@ export function getModelQuickPickItems(
         }
     }
 
-    if (recommendedModels.length > 0) {
-        recommendedModels.unshift({
-            label: 'Recommended Models',
+    const preferredModels = preferredProviderIds.flatMap((providerId) => {
+        const item = preferredModelsById.get(providerId);
+        return item ? [item] : [];
+    });
+
+    if (preferredModels.length > 0) {
+        preferredModels.unshift({
+            label: 'Preferred Models',
             kind: vscode.QuickPickItemKind.Separator,
         });
     }
@@ -223,7 +238,7 @@ export function getModelQuickPickItems(
     }
 
     return [
-        ...recommendedModels,
+        ...preferredModels,
         ...reviewProviders,
         ...otherModels,
         ...unsupportedModels,

--- a/src/vscode/model.ts
+++ b/src/vscode/model.ts
@@ -119,6 +119,23 @@ function getPreferredProviderIds(): string[] {
     return [...new Set([chatModel, ...preferredModels])];
 }
 
+function shouldUseRecommendedModelsLabel(): boolean {
+    const config = vscode.workspace.getConfiguration('lgtm');
+    const chatModel = config.get<string>('chatModel', defaultModelId);
+    const preferredModels = config.get<string[]>(
+        'preferredModels',
+        defaultPreferredModelIds
+    );
+
+    return (
+        chatModel === defaultModelId &&
+        preferredModels.length === defaultPreferredModelIds.length &&
+        preferredModels.every(
+            (modelId, index) => modelId === defaultPreferredModelIds[index]
+        )
+    );
+}
+
 export type ModelQuickPickItem = vscode.QuickPickItem & {
     id?: string;
     providerId?: string;
@@ -199,7 +216,9 @@ export function getModelQuickPickItems(
 
     if (preferredModels.length > 0) {
         preferredModels.unshift({
-            label: 'Preferred Models',
+            label: shouldUseRecommendedModelsLabel()
+                ? 'Recommended Models'
+                : 'Preferred Models',
             kind: vscode.QuickPickItemKind.Separator,
         });
     }

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -21,8 +21,8 @@ export default defineConfig({
                 ...coverageConfigDefaults.exclude,
             ],
             thresholds: {
-                lines: 98.64,
-                functions: 98.48,
+                lines: 98.68,
+                functions: 98.56,
                 autoUpdate: true,
             },
             reporter: ['text', 'lcov'],

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -21,8 +21,8 @@ export default defineConfig({
                 ...coverageConfigDefaults.exclude,
             ],
             thresholds: {
-                lines: 98.41,
-                functions: 98.24,
+                lines: 98.64,
+                functions: 98.48,
                 autoUpdate: true,
             },
             reporter: ['text', 'lcov'],

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -21,7 +21,7 @@ export default defineConfig({
                 ...coverageConfigDefaults.exclude,
             ],
             thresholds: {
-                lines: 98.68,
+                lines: 98.69,
                 functions: 98.56,
                 autoUpdate: true,
             },

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -21,8 +21,8 @@ export default defineConfig({
                 ...coverageConfigDefaults.exclude,
             ],
             thresholds: {
-                lines: 98.69,
-                functions: 98.56,
+                lines: 98.7,
+                functions: 98.57,
                 autoUpdate: true,
             },
             reporter: ['text', 'lcov'],


### PR DESCRIPTION
## Preface

This was built on top of #15 because otherwise there would have been more conflicts than would be worth working around just to implement the two features separately. It has the same commits  as the other PR, so better to review that one first, after that goes in it'll be easier to look over the diffs for this one.

## Description

Introduce GitHub Copilot Code Review as a first-class review provider alongside chat-based review models. This adds end-to-end provider selection and execution support, prepares stable file snapshots so Copilot can review committed and uncommitted changes reliably, improves cancellation and cleanup handling during reviews, and hardens temporary snapshot writes to avoid unsafe paths. The review flow, configuration text, and tests are updated accordingly.

**Note:** while safeguards were added in order to only use the copilot code reviewer when the copilot chat extension exists, it's extremely unlikely those safe-guards will ever be hit; it's a decent assumption that users with LGTM will also have the Github Copilot Chat extension as well.

## Notable Changes

### Copilot Code Review Provider

- Added `copilot-code-review` as a selectable review provider alongside chat models.
- Updated the `/review` command help, provider selection flows, and configuration descriptions to explain inline provider selection and multi-provider comparisons.
- Added provider resolution logic so Copilot Code Review is handled as a dedicated review provider instead of a normal chat model, reducing false matches and improving UX.

### Copilot Review Execution

- Implemented a dedicated Copilot review path that prepares before/after file inputs for the Copilot review command.
- Added snapshot-based file preparation so Copilot reviews work for committed changes, staged changes, unstaged changes, deleted files, and renamed files.
- Mapped Copilot review results back into LGTM comments, including file association, line extraction, and severity normalization.
- Added review progress messaging while files are being gathered for Copilot review.

### Cancellation, Cleanup, and Safety

- Added cancellation handling at multiple points in the Copilot review flow so user-initiated cancellation stops work cleanly.
- Captured temporary file cleanup failures in the review result without discarding successful review comments that were already produced.
- Hardened snapshot path handling to reject any file path that would escape the temporary snapshot directory.

### Integration and Testing

- Integrated the new provider through the main review pipeline, command handling, model/provider selection, and workspace configuration.
- Expanded unit tests to cover Copilot review execution, cancellation behavior, cleanup error handling, provider resolution, and Git snapshot support.