### PR TITLE
Skip binary files for Copilot Code Review

### DIFF
--- a/src/review/copilotCodeReview.ts
+++ b/src/review/copilotCodeReview.ts
@@ -324,6 +324,8 @@ async function findUnreadableReviewInput(
 ): Promise<{ path: string; reason: string } | undefined> {
     for (const input of inputs) {
         try {
+            // Match the downstream review command's ability to open the input
+            // as text instead of relying on a separate binary-file heuristic.
             await vscode.workspace.openTextDocument(input.uri);
         } catch (error) {
             const reason =

--- a/src/review/copilotCodeReview.ts
+++ b/src/review/copilotCodeReview.ts
@@ -67,6 +67,18 @@ type PreparedFile = {
     readonly input: CodeReviewFileInput;
 };
 
+type SkippedPreparedFile = {
+    readonly type: 'skipped';
+    readonly message: string;
+};
+
+type PreparedFileResult =
+    | {
+          readonly type: 'prepared';
+          readonly preparedFile: PreparedFile;
+      }
+    | SkippedPreparedFile;
+
 type FileSnapshotPair =
     | {
           readonly currentContent?: undefined;
@@ -107,7 +119,10 @@ export async function reviewDiffWithCopilotCodeReview(
             };
         }
 
-        tempDir = await mkdtemp(join(tmpdir(), 'lgtm-copilot-review-'));
+        const reviewTempDir = await mkdtemp(
+            join(tmpdir(), 'lgtm-copilot-review-')
+        );
+        tempDir = reviewTempDir;
         const preparedFiles: PreparedFile[] = [];
         const gatheringMessage = formatGatheringFilesMessage(files);
         const gatheringIncrement = files.length > 0 ? 100 / files.length : 0;
@@ -122,9 +137,19 @@ export async function reviewDiffWithCopilotCodeReview(
                 increment: gatheringIncrement,
             });
 
-            preparedFiles.push(
-                await prepareFileForReview(config, request.scope, file, tempDir)
+            const preparedFile = await prepareFileForReview(
+                config,
+                request.scope,
+                file,
+                reviewTempDir
             );
+
+            if (preparedFile.type === 'skipped') {
+                config.logger.debug(preparedFile.message);
+                continue;
+            }
+
+            preparedFiles.push(preparedFile.preparedFile);
         }
 
         if (
@@ -232,7 +257,7 @@ async function prepareFileForReview(
     scope: ReviewScope,
     file: DiffFile,
     tempDir: string
-): Promise<PreparedFile> {
+): Promise<PreparedFileResult> {
     const snapshot = await getFileSnapshotPair(config, scope, file);
 
     const currentUri = snapshot.useWorkspaceFileForCurrent
@@ -254,13 +279,89 @@ async function prepareFileForReview(
                   snapshot.baseContent
               );
 
+    const unreadableInput = await findUnreadableReviewInput([
+        {
+            uri: currentUri,
+            path: file.file,
+        },
+        ...(baseUri
+            ? [
+                  {
+                      uri: baseUri,
+                      path: file.from ?? file.file,
+                  },
+              ]
+            : []),
+    ]);
+
+    if (unreadableInput) {
+        return {
+            type: 'skipped',
+            message: formatUnreadableReviewInputMessage(
+                file.file,
+                unreadableInput
+            ),
+        };
+    }
+
     return {
-        file,
-        input: {
-            currentUri,
-            baseUri,
+        type: 'prepared',
+        preparedFile: {
+            file,
+            input: {
+                currentUri,
+                baseUri,
+            },
         },
     };
+}
+
+async function findUnreadableReviewInput(
+    inputs: ReadonlyArray<{
+        uri: vscode.Uri;
+        path: string;
+    }>
+): Promise<{ path: string; reason: string } | undefined> {
+    for (const input of inputs) {
+        try {
+            await vscode.workspace.openTextDocument(input.uri);
+        } catch (error) {
+            const reason =
+                error instanceof Error ? error.message : String(error);
+            return {
+                path: input.path,
+                reason,
+            };
+        }
+    }
+
+    return undefined;
+}
+
+function formatUnreadableReviewInputMessage(
+    filePath: string,
+    unreadableInput: { path: string; reason: string }
+): string {
+    const normalizedReason = normalizeUnreadableReviewInputReason(
+        unreadableInput.reason
+    );
+
+    if (unreadableInput.path === filePath) {
+        return `Skipping Copilot Code Review file "${filePath}": ${normalizedReason}.`;
+    }
+
+    return `Skipping Copilot Code Review file "${filePath}" because input "${unreadableInput.path}" failed the text-readability check: ${normalizedReason}.`;
+}
+
+function normalizeUnreadableReviewInputReason(reason: string): string {
+    const detailMessage = /^cannot open .*?\. Detail: (.*)$/i.exec(reason)?.[1];
+    const normalizedReason = (detailMessage ?? reason).trim();
+
+    if (/cannot be opened as text|binary/i.test(normalizedReason)) {
+        return 'not readable as text';
+    }
+
+    return normalizedReason;
 }
 
 async function getFileSnapshotPair(

--- a/src/review/copilotCodeReview.ts
+++ b/src/review/copilotCodeReview.ts
@@ -107,7 +107,7 @@ export async function reviewDiffWithCopilotCodeReview(
 ): Promise<ReviewResult> {
     const errors: Error[] = [];
     const fileComments: FileComments[] = [];
-    let tempDir: string | undefined;
+    let tempDir = '';
 
     try {
         if (cancellationToken?.isCancellationRequested) {
@@ -119,10 +119,7 @@ export async function reviewDiffWithCopilotCodeReview(
             };
         }
 
-        const reviewTempDir = await mkdtemp(
-            join(tmpdir(), 'lgtm-copilot-review-')
-        );
-        tempDir = reviewTempDir;
+        tempDir = await mkdtemp(join(tmpdir(), 'lgtm-copilot-review-'));
         const preparedFiles: PreparedFile[] = [];
         const gatheringMessage = formatGatheringFilesMessage(files);
         const gatheringIncrement = files.length > 0 ? 100 / files.length : 0;
@@ -141,7 +138,7 @@ export async function reviewDiffWithCopilotCodeReview(
                 config,
                 request.scope,
                 file,
-                reviewTempDir
+                tempDir
             );
 
             if (preparedFile.type === 'skipped') {

--- a/src/test/unit/review/copilotCodeReview.test.ts
+++ b/src/test/unit/review/copilotCodeReview.test.ts
@@ -974,6 +974,104 @@ describe('reviewDiffWithCopilotCodeReview', () => {
         );
     });
 
+    it('skips renamed files when the base snapshot is unreadable as text', async () => {
+        const config = createConfig();
+        vi.mocked(config.git.getFileContentAtIndex).mockResolvedValue('index');
+        vscodeMocks.openTextDocument.mockImplementation(
+            async (uri: { fsPath: string }) => {
+                if (uri.fsPath.includes(join('src', 'old-name.ts'))) {
+                    throw new Error(
+                        'File seems to be binary and cannot be opened as text'
+                    );
+                }
+
+                return {};
+            }
+        );
+
+        const result = await reviewDiffWithCopilotCodeReview(
+            config as unknown as Config,
+            {
+                scope: {
+                    target: UncommittedRef.Unstaged,
+                    isCommitted: false,
+                    isTargetCheckedOut: true,
+                },
+            } as never,
+            [{ file: 'src/new-name.ts', from: 'src/old-name.ts', status: 'D' }]
+        );
+
+        expect(vscodeMocks.executeCommand).not.toHaveBeenCalled();
+        expect(result.fileComments).toEqual([]);
+        expect(result.errors).toEqual([]);
+        expect(config.logger.debug).toHaveBeenCalledWith(
+            'Skipping Copilot Code Review file "src/new-name.ts" because input "src/old-name.ts" failed the text-readability check: not readable as text.'
+        );
+    });
+
+    it('skips unreadable files for non-binary VS Code open errors and preserves the detail', async () => {
+        const config = createConfig();
+        createWorkspaceFile('good.ts', 'const ok = true;');
+        createWorkspaceFile('locked.txt', 'secret');
+        const activate = vi.fn();
+        vscodeMocks.getExtension.mockReturnValue({ activate });
+        vi.mocked(config.git.getFileContentAtIndex).mockResolvedValue('index');
+        vscodeMocks.openTextDocument.mockImplementation(
+            async (uri: { fsPath: string }) => {
+                if (uri.fsPath === join(config.gitRoot, 'locked.txt')) {
+                    throw new Error(
+                        `Cannot open ${uri.fsPath}. Detail: Permission denied`
+                    );
+                }
+
+                return {};
+            }
+        );
+        vscodeMocks.executeCommand.mockImplementation(
+            async (
+                _command: string,
+                args: {
+                    files: Array<{
+                        currentUri: { fsPath: string };
+                    }>;
+                }
+            ) => {
+                expect(args.files).toHaveLength(1);
+                expect(args.files[0]?.currentUri.fsPath).toBe(
+                    join(config.gitRoot, 'good.ts')
+                );
+
+                return {
+                    type: 'success',
+                    comments: [],
+                };
+            }
+        );
+
+        const result = await reviewDiffWithCopilotCodeReview(
+            config as unknown as Config,
+            {
+                scope: {
+                    target: UncommittedRef.Unstaged,
+                    isCommitted: false,
+                    isTargetCheckedOut: true,
+                },
+            } as never,
+            [
+                { file: 'good.ts', status: 'M' },
+                { file: 'locked.txt', status: 'M' },
+            ]
+        );
+
+        expect(activate).toHaveBeenCalledOnce();
+        expect(vscodeMocks.executeCommand).toHaveBeenCalledOnce();
+        expect(result.fileComments).toEqual([]);
+        expect(result.errors).toEqual([]);
+        expect(config.logger.debug).toHaveBeenCalledWith(
+            'Skipping Copilot Code Review file "locked.txt": Permission denied.'
+        );
+    });
+
     it('returns early when every file is unreadable as text and normalizes wrapped VS Code errors', async () => {
         const config = createConfig();
         createWorkspaceFile('image.png', 'not really png data');

--- a/src/test/unit/review/copilotCodeReview.test.ts
+++ b/src/test/unit/review/copilotCodeReview.test.ts
@@ -2,25 +2,12 @@ import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-
+import { type CancellationToken } from 'vscode';
 import { reviewDiffWithCopilotCodeReview } from '@/review/copilotCodeReview';
 import type { Config } from '@/types/Config';
 import { UncommittedRef } from '@/types/Ref';
+import type { ReviewScope } from '@/types/ReviewRequest';
 import { GIT_EMPTY_TREE_HASH } from '@/utils/git';
-
-type TestGit = {
-    getFileContentAtRef: ReturnType<typeof vi.fn>;
-    getFileContentAtIndex: ReturnType<typeof vi.fn>;
-    getMergeBase: ReturnType<typeof vi.fn>;
-};
-
-type TestConfig = {
-    gitRoot: string;
-    git: TestGit;
-    logger: {
-        debug: ReturnType<typeof vi.fn>;
-    };
-};
 
 const fsPromisesMocks = vi.hoisted(() => ({
     rm: vi.fn(),
@@ -77,7 +64,7 @@ describe('reviewDiffWithCopilotCodeReview', () => {
         return fullPath;
     }
 
-    function createConfig(overrides?: Partial<TestConfig>): TestConfig {
+    function createConfig(overrides?: Partial<Config>) {
         const gitRoot = mkdtempSync(join(tmpdir(), 'lgtm-copilot-test-'));
         tempDirs.push(gitRoot);
 
@@ -92,7 +79,7 @@ describe('reviewDiffWithCopilotCodeReview', () => {
                 debug: vi.fn(),
             },
             ...overrides,
-        };
+        } as Config;
     }
 
     beforeEach(() => {
@@ -192,14 +179,14 @@ describe('reviewDiffWithCopilotCodeReview', () => {
 
         const progress = { report: vi.fn() };
         const result = await reviewDiffWithCopilotCodeReview(
-            config as unknown as Config,
+            config,
             {
                 scope: {
                     target: UncommittedRef.Staged,
                     isCommitted: false,
                     isTargetCheckedOut: true,
                 },
-            } as never,
+            },
             [
                 { file: 'src/file.ts', status: 'M' },
                 { file: 'src/deleted.ts', status: 'D' },
@@ -259,14 +246,14 @@ describe('reviewDiffWithCopilotCodeReview', () => {
 
         const progress = { report: vi.fn() };
         const result = await reviewDiffWithCopilotCodeReview(
-            config as unknown as Config,
+            config,
             {
                 scope: {
                     target: UncommittedRef.Unstaged,
                     isCommitted: false,
                     isTargetCheckedOut: true,
                 },
-            } as never,
+            },
             [
                 { file: 'file1.ts', status: 'M' },
                 { file: 'file2.ts', status: 'M' },
@@ -322,15 +309,15 @@ describe('reviewDiffWithCopilotCodeReview', () => {
         );
 
         const result = await reviewDiffWithCopilotCodeReview(
-            config as unknown as Config,
+            config,
             {
                 scope: {
                     target: 'feature',
                     base: 'main',
                     isCommitted: true,
                     isTargetCheckedOut: true,
-                },
-            } as never,
+                } as ReviewScope,
+            },
             [{ file: 'src/new.ts', status: 'A' }],
             { report: vi.fn() }
         );
@@ -350,15 +337,15 @@ describe('reviewDiffWithCopilotCodeReview', () => {
         vscodeMocks.executeCommand.mockResolvedValue(undefined);
 
         const result = await reviewDiffWithCopilotCodeReview(
-            config as unknown as Config,
+            config,
             {
                 scope: {
                     target: 'feature',
                     base: GIT_EMPTY_TREE_HASH,
                     isCommitted: true,
                     isTargetCheckedOut: true,
-                },
-            } as never,
+                } as ReviewScope,
+            },
             [{ file: 'src/new.ts', status: 'A' }],
             { report: vi.fn() }
         );
@@ -376,15 +363,15 @@ describe('reviewDiffWithCopilotCodeReview', () => {
         vi.mocked(config.git.getFileContentAtRef).mockResolvedValue('target');
 
         const result = await reviewDiffWithCopilotCodeReview(
-            config as unknown as Config,
+            config,
             {
                 scope: {
                     target: 'feature',
                     base: GIT_EMPTY_TREE_HASH,
                     isCommitted: true,
                     isTargetCheckedOut: true,
-                },
-            } as never,
+                } as ReviewScope,
+            },
             [{ file: 'src/new.ts', status: 'A' }]
         );
 
@@ -403,15 +390,15 @@ describe('reviewDiffWithCopilotCodeReview', () => {
         vi.mocked(config.git.getFileContentAtRef).mockResolvedValue('target');
 
         const result = await reviewDiffWithCopilotCodeReview(
-            config as unknown as Config,
+            config,
             {
                 scope: {
                     target: 'feature',
                     base: GIT_EMPTY_TREE_HASH,
                     isCommitted: true,
                     isTargetCheckedOut: true,
-                },
-            } as never,
+                } as ReviewScope,
+            },
             [{ file: 'src/new.ts', status: 'A' }]
         );
 
@@ -426,17 +413,17 @@ describe('reviewDiffWithCopilotCodeReview', () => {
         const config = createConfig();
 
         const result = await reviewDiffWithCopilotCodeReview(
-            config as unknown as Config,
+            config,
             {
                 scope: {
                     target: UncommittedRef.Staged,
                     isCommitted: false,
                     isTargetCheckedOut: true,
                 },
-            } as never,
+            },
             [{ file: 'src/file.ts', status: 'M' }],
             { report: vi.fn() },
-            { isCancellationRequested: true } as never
+            { isCancellationRequested: true } as CancellationToken
         );
 
         expect(result.fileComments).toEqual([]);
@@ -451,14 +438,14 @@ describe('reviewDiffWithCopilotCodeReview', () => {
 
         await expect(
             reviewDiffWithCopilotCodeReview(
-                config as unknown as Config,
+                config,
                 {
                     scope: {
                         target: UncommittedRef.Staged,
                         isCommitted: false,
                         isTargetCheckedOut: true,
                     },
-                } as never,
+                },
                 [{ file: '../escape.ts', status: 'M' }],
                 { report: vi.fn() }
             )
@@ -481,14 +468,14 @@ describe('reviewDiffWithCopilotCodeReview', () => {
         };
 
         const result = await reviewDiffWithCopilotCodeReview(
-            config as unknown as Config,
+            config,
             {
                 scope: {
                     target: UncommittedRef.Staged,
                     isCommitted: false,
                     isTargetCheckedOut: true,
                 },
-            } as never,
+            },
             [
                 { file: 'src/file1.ts', status: 'M' },
                 { file: 'src/file2.ts', status: 'M' },
@@ -510,17 +497,17 @@ describe('reviewDiffWithCopilotCodeReview', () => {
         vi.mocked(config.git.getFileContentAtIndex).mockResolvedValue('index');
 
         const result = await reviewDiffWithCopilotCodeReview(
-            config as unknown as Config,
+            config,
             {
                 scope: {
                     target: UncommittedRef.Staged,
                     isCommitted: false,
                     isTargetCheckedOut: true,
                 },
-            } as never,
+            },
             [{ file: 'src/file.ts', status: 'M' }],
             { report: vi.fn() },
-            { isCancellationRequested: true } as never
+            { isCancellationRequested: true } as CancellationToken
         );
 
         expect(activate).not.toHaveBeenCalled();
@@ -566,14 +553,14 @@ describe('reviewDiffWithCopilotCodeReview', () => {
         };
 
         const reviewPromise = reviewDiffWithCopilotCodeReview(
-            config as unknown as Config,
+            config,
             {
                 scope: {
                     target: UncommittedRef.Staged,
                     isCommitted: false,
                     isTargetCheckedOut: true,
                 },
-            } as never,
+            },
             [{ file: 'src/file.ts', status: 'M' }],
             { report: vi.fn() },
             cancellationToken as never
@@ -611,14 +598,14 @@ describe('reviewDiffWithCopilotCodeReview', () => {
         vi.mocked(config.git.getFileContentAtIndex).mockResolvedValue('index');
 
         const result = await reviewDiffWithCopilotCodeReview(
-            config as unknown as Config,
+            config,
             {
                 scope: {
                     target: UncommittedRef.Staged,
                     isCommitted: false,
                     isTargetCheckedOut: true,
                 },
-            } as never,
+            },
             [{ file: 'src/file.ts', status: 'M' }],
             { report: vi.fn() },
             cancellationToken as never
@@ -641,14 +628,14 @@ describe('reviewDiffWithCopilotCodeReview', () => {
         vscodeMocks.executeCommand.mockRejectedValue(failure);
 
         const result = await reviewDiffWithCopilotCodeReview(
-            config as unknown as Config,
+            config,
             {
                 scope: {
                     target: UncommittedRef.Staged,
                     isCommitted: false,
                     isTargetCheckedOut: true,
                 },
-            } as never,
+            },
             [{ file: 'src/file.ts', status: 'M' }],
             { report: vi.fn() }
         );
@@ -671,20 +658,20 @@ describe('reviewDiffWithCopilotCodeReview', () => {
         vscodeMocks.executeCommand.mockRejectedValue(failure);
 
         const result = await reviewDiffWithCopilotCodeReview(
-            config as unknown as Config,
+            config,
             {
                 scope: {
                     target: UncommittedRef.Staged,
                     isCommitted: false,
                     isTargetCheckedOut: true,
                 },
-            } as never,
+            },
             [{ file: 'src/file.ts', status: 'M' }],
             { report: vi.fn() },
             {
                 isCancellationRequested: false,
                 onCancellationRequested: vi.fn(() => subscription),
-            } as never
+            }
         );
 
         expect(result.fileComments).toEqual([]);
@@ -709,14 +696,14 @@ describe('reviewDiffWithCopilotCodeReview', () => {
         fsPromisesMocks.rm.mockRejectedValue('cleanup failed');
 
         const result = await reviewDiffWithCopilotCodeReview(
-            config as unknown as Config,
+            config,
             {
                 scope: {
                     target: UncommittedRef.Staged,
                     isCommitted: false,
                     isTargetCheckedOut: true,
                 },
-            } as never,
+            },
             [{ file: 'src/file.ts', status: 'M' }],
             { report: vi.fn() }
         );
@@ -816,14 +803,14 @@ describe('reviewDiffWithCopilotCodeReview', () => {
 
         const progress = { report: vi.fn() };
         const result = await reviewDiffWithCopilotCodeReview(
-            config as unknown as Config,
+            config,
             {
                 scope: {
                     target: UncommittedRef.Staged,
                     isCommitted: false,
                     isTargetCheckedOut: true,
                 },
-            } as never,
+            },
             files as never,
             progress
         );
@@ -893,14 +880,14 @@ describe('reviewDiffWithCopilotCodeReview', () => {
         );
 
         const result = await reviewDiffWithCopilotCodeReview(
-            config as unknown as Config,
+            config,
             {
                 scope: {
                     target: UncommittedRef.Unstaged,
                     isCommitted: false,
                     isTargetCheckedOut: true,
                 },
-            } as never,
+            },
             [{ file: 'src/new-name.ts', from: 'src/old-name.ts', status: 'D' }]
         );
 
@@ -950,14 +937,14 @@ describe('reviewDiffWithCopilotCodeReview', () => {
         );
 
         const result = await reviewDiffWithCopilotCodeReview(
-            config as unknown as Config,
+            config,
             {
                 scope: {
                     target: UncommittedRef.Unstaged,
                     isCommitted: false,
                     isTargetCheckedOut: true,
                 },
-            } as never,
+            },
             [
                 { file: 'good.ts', status: 'M' },
                 { file: 'image.png', status: 'M' },
@@ -990,14 +977,14 @@ describe('reviewDiffWithCopilotCodeReview', () => {
         );
 
         const result = await reviewDiffWithCopilotCodeReview(
-            config as unknown as Config,
+            config,
             {
                 scope: {
                     target: UncommittedRef.Unstaged,
                     isCommitted: false,
                     isTargetCheckedOut: true,
                 },
-            } as never,
+            },
             [{ file: 'src/new-name.ts', from: 'src/old-name.ts', status: 'D' }]
         );
 
@@ -1049,14 +1036,14 @@ describe('reviewDiffWithCopilotCodeReview', () => {
         );
 
         const result = await reviewDiffWithCopilotCodeReview(
-            config as unknown as Config,
+            config,
             {
                 scope: {
                     target: UncommittedRef.Unstaged,
                     isCommitted: false,
                     isTargetCheckedOut: true,
                 },
-            } as never,
+            },
             [
                 { file: 'good.ts', status: 'M' },
                 { file: 'locked.txt', status: 'M' },
@@ -1098,14 +1085,14 @@ describe('reviewDiffWithCopilotCodeReview', () => {
         );
 
         const result = await reviewDiffWithCopilotCodeReview(
-            config as unknown as Config,
+            config,
             {
                 scope: {
                     target: UncommittedRef.Unstaged,
                     isCommitted: false,
                     isTargetCheckedOut: true,
                 },
-            } as never,
+            },
             [
                 { file: 'image.png', status: 'M' },
                 { file: 'archive.bin', status: 'M' },
@@ -1173,15 +1160,15 @@ describe('reviewDiffWithCopilotCodeReview', () => {
         );
 
         const result = await reviewDiffWithCopilotCodeReview(
-            config as unknown as Config,
+            config,
             {
                 scope: {
                     target: 'feature',
                     base: 'main',
                     isCommitted: true,
                     isTargetCheckedOut: true,
-                },
-            } as never,
+                } as ReviewScope,
+            },
             [{ file: 'src/file.ts', status: 'D' }]
         );
 

--- a/src/test/unit/review/copilotCodeReview.test.ts
+++ b/src/test/unit/review/copilotCodeReview.test.ts
@@ -974,6 +974,61 @@ describe('reviewDiffWithCopilotCodeReview', () => {
         );
     });
 
+    it('returns early when every file is unreadable as text and normalizes wrapped VS Code errors', async () => {
+        const config = createConfig();
+        createWorkspaceFile('image.png', 'not really png data');
+        createWorkspaceFile('archive.bin', 'not really binary data');
+        const activate = vi.fn();
+        vscodeMocks.getExtension.mockReturnValue({ activate });
+        vi.mocked(config.git.getFileContentAtIndex).mockResolvedValue('index');
+        vscodeMocks.openTextDocument.mockImplementation(
+            async (uri: { fsPath: string }) => {
+                if (uri.fsPath === join(config.gitRoot, 'image.png')) {
+                    throw new Error(
+                        `Cannot open ${uri.fsPath}. Detail: File seems to be binary and cannot be opened as text`
+                    );
+                }
+
+                if (uri.fsPath === join(config.gitRoot, 'archive.bin')) {
+                    throw new Error(
+                        'File seems to be binary and cannot be opened as text'
+                    );
+                }
+
+                return {};
+            }
+        );
+
+        const result = await reviewDiffWithCopilotCodeReview(
+            config as unknown as Config,
+            {
+                scope: {
+                    target: UncommittedRef.Unstaged,
+                    isCommitted: false,
+                    isTargetCheckedOut: true,
+                },
+            } as never,
+            [
+                { file: 'image.png', status: 'M' },
+                { file: 'archive.bin', status: 'M' },
+            ],
+            { report: vi.fn() }
+        );
+
+        expect(activate).not.toHaveBeenCalled();
+        expect(vscodeMocks.executeCommand).not.toHaveBeenCalled();
+        expect(result.fileComments).toEqual([]);
+        expect(result.errors).toEqual([]);
+        expect(config.logger.debug).toHaveBeenNthCalledWith(
+            1,
+            'Skipping Copilot Code Review file "image.png": not readable as text.'
+        );
+        expect(config.logger.debug).toHaveBeenNthCalledWith(
+            2,
+            'Skipping Copilot Code Review file "archive.bin": not readable as text.'
+        );
+    });
+
     it('uses an empty current snapshot when the committed target content is missing', async () => {
         const config = createConfig();
         const activate = vi.fn();

--- a/src/test/unit/review/copilotCodeReview.test.ts
+++ b/src/test/unit/review/copilotCodeReview.test.ts
@@ -17,6 +17,9 @@ type TestGit = {
 type TestConfig = {
     gitRoot: string;
     git: TestGit;
+    logger: {
+        debug: ReturnType<typeof vi.fn>;
+    };
 };
 
 const fsPromisesMocks = vi.hoisted(() => ({
@@ -39,6 +42,7 @@ const vscodeMocks = vi.hoisted(() => ({
     getExtension: vi.fn(),
     executeCommand: vi.fn(),
     getConfiguration: vi.fn(),
+    openTextDocument: vi.fn(),
 }));
 
 vi.mock('vscode', () => ({
@@ -56,6 +60,7 @@ vi.mock('vscode', () => ({
     },
     workspace: {
         getConfiguration: vscodeMocks.getConfiguration,
+        openTextDocument: vscodeMocks.openTextDocument,
     },
 }));
 
@@ -83,6 +88,9 @@ describe('reviewDiffWithCopilotCodeReview', () => {
                 getFileContentAtIndex: vi.fn(),
                 getMergeBase: vi.fn(),
             },
+            logger: {
+                debug: vi.fn(),
+            },
             ...overrides,
         };
     }
@@ -92,6 +100,7 @@ describe('reviewDiffWithCopilotCodeReview', () => {
             throw new Error('Expected node:fs/promises.rm to be initialized.');
         }
         fsPromisesMocks.rm.mockImplementation(fsPromisesMocks.actualRm);
+        vscodeMocks.openTextDocument.mockResolvedValue({});
         vscodeMocks.getConfiguration.mockReturnValue({
             get: vi.fn((_key: string, fallback?: boolean) => fallback),
         });
@@ -899,6 +908,70 @@ describe('reviewDiffWithCopilotCodeReview', () => {
         expect(
             result.fileComments[0]?.comments.map((comment) => comment.severity)
         ).toEqual([3, 2]);
+    });
+
+    it('skips files that VS Code cannot open as text before starting Copilot review', async () => {
+        const config = createConfig();
+        createWorkspaceFile('good.ts', 'const ok = true;');
+        createWorkspaceFile('image.png', 'not really png data');
+        const activate = vi.fn();
+        vscodeMocks.getExtension.mockReturnValue({ activate });
+        vi.mocked(config.git.getFileContentAtIndex).mockResolvedValue('index');
+        vscodeMocks.openTextDocument.mockImplementation(
+            async (uri: { fsPath: string }) => {
+                if (uri.fsPath === join(config.gitRoot, 'image.png')) {
+                    throw new Error(
+                        'File seems to be binary and cannot be opened as text'
+                    );
+                }
+
+                return {};
+            }
+        );
+        vscodeMocks.executeCommand.mockImplementation(
+            async (
+                _command: string,
+                args: {
+                    files: Array<{
+                        currentUri: { fsPath: string };
+                    }>;
+                }
+            ) => {
+                expect(args.files).toHaveLength(1);
+                expect(args.files[0]?.currentUri.fsPath).toBe(
+                    join(config.gitRoot, 'good.ts')
+                );
+
+                return {
+                    type: 'success',
+                    comments: [],
+                };
+            }
+        );
+
+        const result = await reviewDiffWithCopilotCodeReview(
+            config as unknown as Config,
+            {
+                scope: {
+                    target: UncommittedRef.Unstaged,
+                    isCommitted: false,
+                    isTargetCheckedOut: true,
+                },
+            } as never,
+            [
+                { file: 'good.ts', status: 'M' },
+                { file: 'image.png', status: 'M' },
+            ],
+            { report: vi.fn() }
+        );
+
+        expect(activate).toHaveBeenCalledOnce();
+        expect(vscodeMocks.executeCommand).toHaveBeenCalledOnce();
+        expect(result.fileComments).toEqual([]);
+        expect(result.errors).toEqual([]);
+        expect(config.logger.debug).toHaveBeenCalledWith(
+            'Skipping Copilot Code Review file "image.png": not readable as text.'
+        );
     });
 
     it('uses an empty current snapshot when the committed target content is missing', async () => {

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -21,8 +21,8 @@ export default defineConfig({
                 ...coverageConfigDefaults.exclude,
             ],
             thresholds: {
-                lines: 98.7,
-                functions: 98.57,
+                lines: 98.73,
+                functions: 98.6,
                 autoUpdate: true,
             },
             reporter: ['text', 'lcov'],


### PR DESCRIPTION
Just discovered that Copilot Code Review does not handle binary files. Through the normal methods it ignores them silently, but with the last patch here it would cause an error in the review process (only for Copilot Code Review, if the user selected others to run simultaneously, they would still run and report).

I think the solution is straightforward, do what the native Copilot Code Review does, skip them.

(If only I was a couple of hours earlier, this could have made 1.5.0? 😄)